### PR TITLE
Update the link to Microsoft Store in README (Microsoft changed all the links to the store??)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This app was built with [Electron](https://electronjs.org/), [Node.js](https://n
 
 **Download the lastest version from [twinkletray.com](https://twinkletray.com/) or the [Releases page](https://github.com/xanderfrangos/twinkle-tray/releases).**
 
-<a href="https://www.microsoft.com/store/apps/9PLJWWSV01LK" target="_blank"><img width="156" src="https://crushee.app/assets/img/ms-store.svg" alt="Get Twinkle Tray brightness slider from the Microsoft Store"></a>
+<a href="https://www.microsoft.com/store/productId/9PLJWWSV01LK" target="_blank"><img width="156" src="https://crushee.app/assets/img/ms-store.svg" alt="Get Twinkle Tray brightness slider from the Microsoft Store"></a>
 
 ## Usage
 


### PR DESCRIPTION
Hi, just stumbled upon this gem and suddenly the link to the store was not working. 

Least I could do was fix it 🤷🏻‍♂️

Thanks for the good work :). It works flawlessly for me on ASUS MG279Q & ASUS PG278QR.