### PR TITLE
Fixed not restoring brightness after resume

### DIFF
--- a/src/electron.js
+++ b/src/electron.js
@@ -2376,7 +2376,7 @@ function handleMonitorChange(e, d) {
 
 // Handle resume from sleep/hibernation
 powerMonitor.on("resume", () => {
-
+  console.log("Resuming......")
   setTimeout(
     () => {
       refreshMonitors().then(() => {
@@ -2388,7 +2388,7 @@ powerMonitor.on("resume", () => {
         handleBackgroundUpdate()
       })
     },
-    1500 // Give Windows a few seconds to... you know... wake up.
+    1900 // Give Windows a few seconds to... you know... wake up.
   )
 
 })


### PR DESCRIPTION
Some Samsung monitors take longer to initialize after waking up. Brightness restoration may fail during that initialization. Fixed it via adding some delay.