### PR TITLE
Add instructions for downloading with package managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Twinkle Tray will automatically adjust the look and feel to match your Windows v
 
 ## Install via Package Manager
 
+### Windows Package Manager
+
+```powershell
+winget install twinkletray
+```
+
 ### Chocolatey (unofficial)
 
 [Chocolatey](https://chocolatey.org/) users can download and install Twinkle Tray from Chocolatey's Community Repository by installing the `twinkle-tray` package:
@@ -47,12 +53,6 @@ choco upgrade twinkle-tray
 ```
 
 **This package is not maintained at this repository**. Please do not create issues relating to the package here. Instead, go to the [package page](https://community.chocolatey.org/packages/twinkle-tray) and follow the [Package Triage Process](https://docs.chocolatey.org/en-us/community-repository/users/package-triage-process).
-
-### Windows Package Manager
-
-```powershell
-winget install twinkletray
-```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Twinkle Tray will automatically adjust the look and feel to match your Windows v
 
 <a href="https://www.microsoft.com/store/productId/9PLJWWSV01LK" target="_blank"><img width="156" src="https://crushee.app/assets/img/ms-store.svg" alt="Get Twinkle Tray brightness slider from the Microsoft Store"></a>
 
-### Via Chocolatey (unofficial)
+## Install via Package Manager
+
+### Chocolatey (unofficial)
 
 [Chocolatey](https://chocolatey.org/) users can download and install Twinkle Tray from Chocolatey's Community Repository by installing the `twinkle-tray` package:
 
@@ -45,6 +47,12 @@ choco upgrade twinkle-tray
 ```
 
 **This package is not maintained at this repository**. Please do not create issues relating to the package here. Instead, go to the [package page](https://community.chocolatey.org/packages/twinkle-tray) and follow the [Package Triage Process](https://docs.chocolatey.org/en-us/community-repository/users/package-triage-process).
+
+### Windows Package Manager
+
+```powershell
+winget install twinkletray
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ Twinkle Tray will automatically adjust the look and feel to match your Windows v
 
 <a href="https://www.microsoft.com/store/productId/9PLJWWSV01LK" target="_blank"><img width="156" src="https://crushee.app/assets/img/ms-store.svg" alt="Get Twinkle Tray brightness slider from the Microsoft Store"></a>
 
+### Via Chocolatey (unofficial)
+
+[Chocolatey](https://chocolatey.org/) users can download and install Twinkle Tray from Chocolatey's Community Repository by installing the `twinkle-tray` package:
+
+```powershell
+choco install twinkle-tray
+```
+
+To upgrade to the latest approved package version, run the following command:
+
+```powershell
+choco upgrade twinkle-tray
+```
+
+**This package is not maintained at this repository**. Please do not create issues relating to the package here. Instead, go to the [package page](https://community.chocolatey.org/packages/twinkle-tray) and follow the [Package Triage Process](https://docs.chocolatey.org/en-us/community-repository/users/package-triage-process).
+
 ## Usage
 
 - Download from the [Releases page](https://github.com/xanderfrangos/twinkle-tray/releases) and run the installer EXE.


### PR DESCRIPTION
I was updating the Chocolatey package I created a while ago to consume the newly released versions. You had mentioned the `README` will be updated to reflect the package's availability [here](https://github.com/xanderfrangos/twinkle-tray/issues/279#issuecomment-1112237443).

In reviewing the latest revision, I noticed this hasn't been done yet. Figured I'd take matters into my own hands...