### PR TITLE
Handle Apple Studio Display Brightness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "node-fetch": "^2.6.1",
         "setwindowpos-binding": "file:src/modules/setwindowpos",
         "sharp": "^0.30.7",
+        "studio-display-control": "^0.2.0",
         "win32-displayconfig": "^0.1.0",
         "windows-accent-colors": "^1.0.0",
         "wmi-bridge": "file:src/modules/wmi-bridge",
@@ -43,6 +44,31 @@
         "react-dom": "^17.0.0",
         "sass": "^1.54.0",
         "wait-on": "^5.3.0"
+      }
+    },
+    "../asdbctl": {
+      "version": "0.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@napi-rs/cli": "^2.18.1",
+        "ava": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "asdbctl-freebsd-x64": "0.0.0",
+        "asdbctl-linux-arm-gnueabihf": "0.0.0",
+        "asdbctl-linux-arm-musleabihf": "0.0.0",
+        "asdbctl-linux-arm64-gnu": "0.0.0",
+        "asdbctl-linux-arm64-musl": "0.0.0",
+        "asdbctl-linux-riscv64-gnu": "0.0.0",
+        "asdbctl-linux-x64-gnu": "0.0.0",
+        "asdbctl-linux-x64-musl": "0.0.0",
+        "asdbctl-win32-arm64-msvc": "0.0.0",
+        "asdbctl-win32-ia32-msvc": "0.0.0",
+        "asdbctl-win32-x64-msvc": "0.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2490,6 +2516,11 @@
       "integrity": "sha512-MLx9Z+9lGzwEuW16ubGeNkpBDE84RpB/NyGgg6z2BTpWzKkGU451cAY3UkUzZEp72RHF585oJ3V8JVNqIplcAQ==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/@types/w3c-web-usb": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-usb/-/w3c-web-usb-1.0.10.tgz",
+      "integrity": "sha512-CHgUI5kTc/QLMP8hODUHhge0D4vx+9UiAwIGiT0sTy/B2XpdX1U5rJt6JSISgr6ikRT7vxV9EVAFeYZqUnl1gQ=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
@@ -13141,6 +13172,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/studio-display-control": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/studio-display-control/-/studio-display-control-0.2.0.tgz",
+      "integrity": "sha512-ZnJz1Oy4g8EApJWYotFtvMgOgBe47AadXdBc26MmMVEkdkFQDqvgwzvywQuy4ASE0di/tl5/IRnNYW7IWJmirA==",
+      "dependencies": {
+        "usb": "2.12.1"
+      },
+      "bin": {
+        "sdctl": "bin/sdctl.js"
+      }
+    },
     "node_modules/stylehacks": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
@@ -14155,6 +14197,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/usb": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/usb/-/usb-2.12.1.tgz",
+      "integrity": "sha512-hgtoSQUFuMXVJBApelpUTiX7ZB83MQCbYeHTBsHftA2JG7YZ76ycwIgKQhkhKqVY76C8K6xJscHpF7Ep0eG3pQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@types/w3c-web-usb": "^1.0.6",
+        "node-addon-api": "^7.0.0",
+        "node-gyp-build": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=12.22.0 <13.0 || >=14.17.0"
+      }
+    },
+    "node_modules/usb/node_modules/node-addon-api": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
+      "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
+      "engines": {
+        "node": "^16 || ^18 || >= 20"
       }
     },
     "node_modules/use": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "node-fetch": "^2.6.1",
     "setwindowpos-binding": "file:src/modules/setwindowpos",
     "sharp": "^0.30.7",
+    "studio-display-control": "^0.2.0",
     "win32-displayconfig": "^0.1.0",
     "windows-accent-colors": "^1.0.0",
     "wmi-bridge": "file:src/modules/wmi-bridge",

--- a/src/components/BrightnessPanel.jsx
+++ b/src/components/BrightnessPanel.jsx
@@ -24,7 +24,7 @@ export default class BrightnessPanel extends PureComponent {
         let lastValidMonitor
         for(const key in this.state.monitors) {
           const monitor = this.state.monitors[key]
-          if(monitor.type == "wmi" || (monitor.type == "ddcci" && monitor.brightnessType)) {
+          if(monitor.type == "wmi" || monitor.type == "studio-display" || (monitor.type == "ddcci" && monitor.brightnessType)) {
            lastValidMonitor = monitor 
           }
         }
@@ -52,7 +52,7 @@ export default class BrightnessPanel extends PureComponent {
           if (monitor.type == "none" || window.settings?.hideDisplays?.[monitor.key] === true) {
             return (<div key={monitor.key}></div>)
           } else {
-            if (monitor.type == "wmi" || (monitor.type == "ddcci" && monitor.brightnessType)) {
+            if (monitor.type == "wmi" || monitor.type == "studio-display" || (monitor.type == "ddcci" && monitor.brightnessType)) {
 
               let hasFeatures = true
               let featureCount = 0

--- a/src/components/MonitorFeatures.jsx
+++ b/src/components/MonitorFeatures.jsx
@@ -68,6 +68,8 @@ function getDebugMonitorType(type) {
         return (<><b>DDC/CI</b> <span className="icon green vfix">&#xE73D;</span></>)
     } else if (type == "wmi") {
         return (<><b>WMI</b> <span className="icon green vfix">&#xE73D;</span></>)
+    } else if (type == "studio-display") {
+        return (<><b>Studio Display</b> <span className="icon green vfix">&#xE73D;</span></>)
     } else {
         return (<><b>Unknown ({type})</b> <span className="icon red vfix">&#xEB90;</span></>)
     }

--- a/src/components/MonitorInfo.jsx
+++ b/src/components/MonitorInfo.jsx
@@ -83,6 +83,8 @@ function getDebugMonitorType(type) {
         return (<><b>DDC/CI</b> <span className="icon green vfix">&#xE73D;</span></>)
     } else if (type == "wmi") {
         return (<><b>WMI</b> <span className="icon green vfix">&#xE73D;</span></>)
+    } else if (type == "studio-display") {
+        return (<><b>Studio Display</b> <span className="icon green vfix">&#xE73D;</span></>)
     } else {
         return (<><b>Unknown ({type})</b> <span className="icon red vfix">&#xEB90;</span></>)
     }

--- a/src/components/SettingsWindow.jsx
+++ b/src/components/SettingsWindow.jsx
@@ -796,6 +796,8 @@ export default class SettingsWindow extends PureComponent {
             return (<><b>DDC/CI</b> <span className="icon green vfix">&#xE73D;</span></>)
         } else if (type == "wmi") {
             return (<><b>WMI</b> <span className="icon green vfix">&#xE73D;</span></>)
+        } else if (type == "studio-display") {
+            return (<><b>Studio Display</b> <span className="icon green vfix">&#xE73D;</span></>)
         } else {
             return (<><b>Unknown ({type})</b> <span className="icon red vfix">&#xEB90;</span></>)
         }

--- a/src/electron.js
+++ b/src/electron.js
@@ -681,7 +681,7 @@ function applyProfile(profile = {}, useTransition = false, transitionSpeed = 1) 
         const monitor = profile[hwid]
   
         // Apply brightness to valid display types
-        if (monitor.type == "wmi" || (monitor.type == "ddcci" && monitor.brightnessType)) {
+        if (monitor.type == "wmi" || monitor.type == "studio-display" || (monitor.type == "ddcci" && monitor.brightnessType)) {
           updateBrightness(monitor.id, monitor.brightness)
         }
       } catch (e) { console.log("Couldn't set brightness for known display!") }
@@ -819,7 +819,7 @@ async function hotkeyOverlayShow() {
   panelState = "overlay"
   let monitorCount = 0
   Object.values(monitors).forEach((monitor) => {
-    if ((monitor.type === "ddcci" || monitor.type === "wmi") && (settings?.hideDisplays?.[monitor.key] !== true)) monitorCount++;
+    if ((monitor.type === "ddcci" || monitor.type === "studio-display" || monitor.type === "wmi") && (settings?.hideDisplays?.[monitor.key] !== true)) monitorCount++;
   })
 
   if (monitorCount && settings.linkedLevelsActive) {
@@ -1444,7 +1444,7 @@ function updateBrightness(index, level, useCap = true, vcp = "brightness", clear
 
     const normalized = normalizeBrightness(level, false, (useCap ? monitor.min : 0), (useCap ? monitor.max : 100))
 
-    if (monitor.type == "ddcci" && vcp === "brightness") {
+    if ((monitor.type == "ddcci" && vcp === "brightness") || monitor.type === "studio-display") {
       monitor.brightness = level
       monitor.brightnessRaw = normalized
       monitorsThread.send({


### PR DESCRIPTION
This uses [studio-display-control](https://github.com/jridgewell/studio-display-control) to communicate with an Apple Studio Display via [usb](https://github.com/node-usb/node-usb). I basically just ported over https://github.com/juliuszint/asdbctl into a node package.

![studio-display](https://github.com/xanderfrangos/twinkle-tray/assets/112982/87894846-1307-4a90-a3aa-b3f1eb7372d7)


I'm kinda abusing the serial number to uniquely identify the display. I don't have any DDC/CI displays, so I'm not really sure what the `key` and `id` values are supposed to be in the normal paths. I also don't know how to support renaming the display, but I'm happy to update if you can tell me how.

Fixes #705
Fixes #713 
Fixes #489