### PR TITLE
Fix Beta Apple Studio Display integration

### DIFF
--- a/src/Monitors.js
+++ b/src/Monitors.js
@@ -408,7 +408,7 @@ getStudioDisplay = async (monitors) => {
                 "APPAE3A",
                 `APLSTD-${serial}-NUM${count}`
             ]
-            updateDisplay(monitors, serial, {
+            updateDisplay(monitors, hwid[2], {
                 name: "Apple Studio Display",
                 type: "studio-display",
                 key: hwid[2],

--- a/src/electron.js
+++ b/src/electron.js
@@ -1916,14 +1916,6 @@ function updateBrightness(index, newLevel, useCap = true, vcpValue = "brightness
             }
           }
         }
-      } else if (monitor.type === "studio-display") {
-        monitor.brightness = level
-        monitor.brightnessRaw = normalized
-        monitorsThread.send({
-          type: "brightness",
-          brightness: normalized * ((monitor.brightnessMax || 100) / 100),
-          id: monitor.id
-        })
       } else {
         const vcpString = `0x${parseInt(vcp).toString(16).toUpperCase()}`
         try {
@@ -1950,7 +1942,14 @@ function updateBrightness(index, newLevel, useCap = true, vcpValue = "brightness
           console.log(`Couldn't set VCP code ${vcpString} for monitor ${monitor.id}`, e)
         }
       }
-
+    } else if (monitor.type === "studio-display") {
+      monitor.brightness = level
+      monitor.brightnessRaw = normalized
+      monitorsThread.send({
+        type: "brightness",
+        brightness: normalized * ((monitor.brightnessMax || 100) / 100),
+        id: monitor.id
+      })
     } else if (monitor.type == "wmi") {
       monitor.brightness = level
       monitor.brightnessRaw = normalized


### PR DESCRIPTION
A couple of bugs crept in with 6c8501a6 that stopped the integration from working.

1. The changes in id/serial/key didn't update the `monitors` mapping to use updated `hwid`.
2. The thread messaging was never sent for `type === 'studio-display'` because it was nested inside a `type === 'ddcci'` if-statement.