### PR TITLE
docs(README): add unofficial Scoop package instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ choco upgrade twinkle-tray
 
 **This package is not maintained at this repository**. Please do not create issues relating to the package here. Instead, go to the [package page](https://community.chocolatey.org/packages/twinkle-tray) and follow the [Package Triage Process](https://docs.chocolatey.org/en-us/community-repository/users/package-triage-process).
 
+### Scoop (unofficial)
+
+[Scoop](https://scoop.sh/) users can download and install Twinkle Tray from Scoop's Extras bucket by installing the `twinkle-tray` package:
+
+```sh
+scoop bucket add extras
+scoop install extras/twinkle-tray
+```
+
+To upgrade to the latest approved package version, run the following command:
+
+```sh
+scoop update twinkle-tray
+```
+
+**This package is not maintained at this repository**. Please do not create issues relating to the package here. Instead, go to [ScoopInstallers/Extras](https://github.com/ScoopInstaller/Extras) and search for an existing [issue](https://github.com/ScoopInstaller/Extras/issues?q=is%3Aissue+twinkle-tray) or [discussion](https://github.com/ScoopInstaller/Extras/discussions?discussions_q=twinkle-tray) and create a new [issue](https://github.com/ScoopInstaller/Extras/issues/new/choose) or [discussion](https://github.com/ScoopInstaller/Extras/discussions/new/choose) if one does not already exist.
+
 ## Usage
 
 - Download from the [Releases page](https://github.com/xanderfrangos/twinkle-tray/releases) and run the installer EXE.


### PR DESCRIPTION
There are a few Scoop packages for Twinkle Tray. This PR instructs users to install `twinkle-tray' package from the official 'extras' bucket instead of from one of the community buckets.