### PR TITLE
Add "Invert Scroll" toggle to settings

### DIFF
--- a/src/components/SettingsWindow.jsx
+++ b/src/components/SettingsWindow.jsx
@@ -1298,6 +1298,7 @@ export default class SettingsWindow extends PureComponent {
                                                 this.forceUpdate()
                                             }} />
                                         } />
+                                        <SettingsChild title={T.t("SETTINGS_HOTKEYS_INVERT_SCROLL_TITLE")} description={T.t("SETTINGS_HOTKEYS_INVERT_SCROLL_DESC")} input={this.renderToggle("invertScroll")} />
                                     </SettingsOption>
                                 </div>
 

--- a/src/electron.js
+++ b/src/electron.js
@@ -278,7 +278,8 @@ function enableMouseEvents() {
       try {
         if (!bounds) return false;
         if (event.x >= bounds.x && event.x <= bounds.x + bounds.width && event.y >= bounds.y && event.y <= bounds.y + bounds.height) {
-          const amount = Math.round(event.delta) * settings.scrollShortcutAmount;
+          const delta = settings.invertScroll ? -Math.round(event.delta) : Math.round(event.delta);
+          const amount = delta * settings.scrollShortcutAmount;
 
           refreshMonitors()
           updateAllBrightness(amount)
@@ -445,6 +446,7 @@ const defaultSettings = {
   scrollShortcut: true,
   scrollShortcutAmount: 2,
   scrollFlyoutAmount: 2,
+  invertScroll: false,
   useAcrylic: false,
   useNativeAnimation: false,
   sleepAction: "ps",

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -170,6 +170,8 @@
     "SETTINGS_HOTKEYS_LEVEL_TITLE": "Brightness level adjustment",
     "SETTINGS_HOTKEYS_LEVEL_DESC": "How much the brightness should be adjusted when using hotkeys.",
     "SETTINGS_HOTKEYS_SCROLL_AMOUNT": "Amount to scroll",
+    "SETTINGS_HOTKEYS_INVERT_SCROLL_TITLE": "Invert scroll",
+    "SETTINGS_HOTKEYS_INVERT_SCROLL_DESC": "When scrolling over the system tray icon, the scroll direction will be reversed.",
     "SETTINGS_HOTKEYS_TOD_TITLE": "Turn Off Displays action",
     "SETTINGS_HOTKEYS_TOD_DESC": "Customize the signal sent when using the Turn Off Displays hotkey or icon. The software signal will display a black screen until input (ex. mouse or keyboard) is detected by Windows. The hardware signal will turn off power to the monitors.",
     "SETTINGS_HOTKEYS_TOD_NONE": "None (hide icon)",


### PR DESCRIPTION
As per feature request #899, added an _"Invert scroll"_ toggle to settings under _Hotkeys & Shortcuts_.

This is for users who wish to use an inverted mouse scroll setup, so when adjusting display brightness by scrolling over the system tray icon, the mouse direction will be reversed.

![image](https://github.com/user-attachments/assets/3b3b17dd-b0e4-413d-9f2d-68693471ce84)
