### PR TITLE
Add Disable on Lock Screen feature

### DIFF
--- a/src/components/SettingsWindow.jsx
+++ b/src/components/SettingsWindow.jsx
@@ -1030,6 +1030,8 @@ export default class SettingsWindow extends PureComponent {
 
                                     <SettingsOption title={T.t("SETTINGS_GENERAL_BRIGHTNESS_STARTUP_TITLE")} description={T.t("SETTINGS_GENERAL_BRIGHTNESS_STARTUP_DESC")} input={this.renderToggle("brightnessAtStartup")} />
 
+                                    <SettingsOption title={T.t("SETTINGS_GENERAL_DISABLE_ON_LOCK_SCREEN_TITLE")} description={T.t("SETTINGS_GENERAL_DISABLE_ON_LOCK_SCREEN_DESC")} input={this.renderToggle("disableOnLockScreen")} />
+
                                     <SettingsOption title={T.t("SETTINGS_GENERAL_LANGUAGE_TITLE")} input={(
                                         <select value={window.settings.language} onChange={(e) => {
                                             this.setState({ language: e.target.value })

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -57,6 +57,8 @@
     "SETTINGS_GENERAL_STARTUP": "Launch at startup",
     "SETTINGS_GENERAL_BRIGHTNESS_STARTUP_TITLE": "Apply brightness at startup",
     "SETTINGS_GENERAL_BRIGHTNESS_STARTUP_DESC": "Restore the last known brightness for each display when Twinkle Tray starts.",
+    "SETTINGS_GENERAL_DISABLE_ON_LOCK_SCREEN_TITLE": "Disable on Lock Screen",
+    "SETTINGS_GENERAL_DISABLE_ON_LOCK_SCREEN_DESC": "Don't access monitors while the user session is locked to avoid conflicts in multi-user environments.",
     "SETTINGS_GENERAL_THEME_TITLE": "Theme",
     "SETTINGS_GENERAL_THEME_SYSTEM": "System preferences (default)",
     "SETTINGS_GENERAL_THEME_DARK": "Dark",


### PR DESCRIPTION
The "Disable on Lock Screen" option allows Twinkle Tray to work in a multi-user environment by keeping only one instance responsible for controlling display parameters. It also prevents unnecessary commands from being sent to the display during the transition to sleep mode, especially if the software has not yet detected that the display is in standby mode.

Fixes #1039.