### PR TITLE
Fix clipping of long expected value strings

### DIFF
--- a/src/css/page.scss
+++ b/src/css/page.scss
@@ -369,6 +369,7 @@ label {
     .supported-values {
         font-size: 16px;
         opacity: 0.7;
+        overflow-wrap: anywhere;
     }
 }
 


### PR DESCRIPTION
#### Before
<img width="2250" height="925" alt="image" src="https://github.com/user-attachments/assets/f736a5b3-8225-46a0-9c66-3d378d865b81" />

#### After
<img width="2250" height="925" alt="image" src="https://github.com/user-attachments/assets/ce1483d6-6f4a-41d8-82b8-8ec70306e38e" />
