### PR TITLE
BUGFIX: Monitors should be identified by paths, otherwise setups with multiple same monitors don't work

### DIFF
--- a/src/modules/windows-hdr/windows-hdr.cc
+++ b/src/modules/windows-hdr/windows-hdr.cc
@@ -177,7 +177,7 @@ std::map<std::string, Display> getDisplays() {
         newDisplay.hdrActive = setSDRBrightness(path, nits, true);
       }
 
-      newDisplays.insert({newDisplay.name, newDisplay});
+      newDisplays.insert({newDisplay.path, newDisplay});
     }
 
     return newDisplays;
@@ -234,7 +234,7 @@ Napi::Boolean nodeSetSDRBrightness(const Napi::CallbackInfo& info) {
     return Napi::Boolean::New(info.Env(), result);
 }
 
-Napi::Object Init(Napi::Env env, Napi::Object exports) { 
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
     exports.Set(Napi::String::New(env, "getDisplays"), Napi::Function::New(env, nodeGetDisplays));
     exports.Set(Napi::String::New(env, "setSDRBrightness"), Napi::Function::New(env, nodeSetSDRBrightness));
     return exports;


### PR DESCRIPTION
If a user has two or more monitors of the same model, `display.name` will be the same between them. That breaks HDR detection as only the last one will be added to a map (previous records will be replaced). Monitors should be identified by path instead. This PR addresses that. The end result is a correct behaviour:

<img width="546" height="484" alt="image" src="https://github.com/user-attachments/assets/7415c0ae-b204-457a-b96a-3d823067dbb9" />

Behaviour before the fix:

<img width="547" height="422" alt="image" src="https://github.com/user-attachments/assets/cc08ad1c-1bd8-46a7-a55f-c8adcf44448c" />
