### PR TITLE
fix: add keyboard activation for panel action controls

### DIFF
--- a/src/components/BrightnessPanel.jsx
+++ b/src/components/BrightnessPanel.jsx
@@ -42,6 +42,13 @@ const BrightnessPanel = memo(function BrightnessPanel() {
     })
   }
 
+  const handleActionKeyDown = (event, action) => {
+    if (event.key === "Enter" || event.key === " " || event.key === "Spacebar") {
+      event.preventDefault()
+      action()
+    }
+  }
+
   // Handle <Slider> changes
   const handleChange = (level, slider) => {
     const monitors = { ...state.monitors }
@@ -295,7 +302,17 @@ const BrightnessPanel = memo(function BrightnessPanel() {
               const showPowerButton = () => {
                 const customFeatureEnabled = window.settings?.monitorFeaturesSettings?.[monitor?.hwid[1]]?.["0xD6"]
                 if (monitorFeatures?.["0xD6"] && (monitor.features?.["0xD6"] || customFeatureEnabled)) {
-                  return (<div className="feature-power-icon simple" onClick={powerOff}><span className="icon vfix">&#xE7E8;</span><span>{(monitor.features?.["0xD6"][0] >= 4 ? T.t("PANEL_LABEL_TURN_ON") : T.t("PANEL_LABEL_TURN_OFF"))}</span></div>)
+                  return (
+                    <div
+                      className="feature-power-icon simple"
+                      role="button"
+                      tabIndex={0}
+                      onClick={powerOff}
+                      onKeyDown={(event) => handleActionKeyDown(event, powerOff)}>
+                      <span className="icon vfix">&#xE7E8;</span>
+                      <span>{(monitor.features?.["0xD6"][0] >= 4 ? T.t("PANEL_LABEL_TURN_ON") : T.t("PANEL_LABEL_TURN_OFF"))}</span>
+                    </div>
+                  )
                 }
               }
 
@@ -363,6 +380,9 @@ const BrightnessPanel = memo(function BrightnessPanel() {
               title={T.t("PANEL_BUTTON_LINK_LEVELS")}
               data-active={state.linkedLevelsActive}
               onClick={toggleLinkedLevels}
+              onKeyDown={(event) => handleActionKeyDown(event, toggleLinkedLevels)}
+              role="button"
+              tabIndex={0}
               className="link">
               &#xE71B;
             </div>
@@ -372,11 +392,22 @@ const BrightnessPanel = memo(function BrightnessPanel() {
             <div
               title={T.t("PANEL_BUTTON_TURN_OFF_DISPLAYS")}
               className="off"
-              onClick={window.turnOffDisplays}>
+              onClick={window.turnOffDisplays}
+              onKeyDown={(event) => handleActionKeyDown(event, window.turnOffDisplays)}
+              role="button"
+              tabIndex={0}>
               &#xF71D;
             </div>
           }
-          <div title={T.t("GENERIC_SETTINGS")} className="settings" onClick={window.openSettings}>&#xE713;</div>
+          <div
+            title={T.t("GENERIC_SETTINGS")}
+            className="settings"
+            onClick={window.openSettings}
+            onKeyDown={(event) => handleActionKeyDown(event, window.openSettings)}
+            role="button"
+            tabIndex={0}>
+            &#xE713;
+          </div>
         </div>
       </div>
       {state.sleeping ? (<div></div>) : getMonitors()}
@@ -389,10 +420,20 @@ const BrightnessPanel = memo(function BrightnessPanel() {
               ({state.update.version})
             </div>
             <div className="right">
-              <a onClick={window.installUpdate}>
+              <a
+                role="button"
+                tabIndex={0}
+                onClick={window.installUpdate}
+                onKeyDown={(event) => handleActionKeyDown(event, window.installUpdate)}>
                 {T.t("GENERIC_INSTALL")}
               </a>
-              <a className="icon" title={T.t("GENERIC_DISMISS")} onClick={window.dismissUpdate}>
+              <a
+                className="icon"
+                title={T.t("GENERIC_DISMISS")}
+                role="button"
+                tabIndex={0}
+                onClick={window.dismissUpdate}
+                onKeyDown={(event) => handleActionKeyDown(event, window.dismissUpdate)}>
                 &#xEF2C;
               </a>
             </div>


### PR DESCRIPTION
## Change plan (5 bullets)
- Observed behavior: open issue #1195 reports tray controls are not keyboard-activatable.
- Expected behavior: interactive panel controls should be reachable with Tab and trigger with Enter/Space.
- Suspected root cause: click-only elements (div/a) in the panel UI lacked keyboard semantics/handlers.
- Safest seam to modify: only `BrightnessPanel.jsx`.
- Risk surface: low; UI activation wiring only, no monitor control logic changes.

## Reproduction evidence
- Issue evidence: #1195 describes keyboard inability to activate controls.
- Code-level repro (pre-fix pattern): clickable controls in panel used `onClick` without keyboard activation support.
- Manual repro recipe:
  1. Open Twinkle Tray panel from system tray.
  2. Navigate controls with Tab.
  3. Try Enter/Space on link-level toggle / turn-off / settings / update actions.
  4. Before fix: no action for keyboard activation on these click-only controls.

## Minimal patch summary
- Added a single helper `handleActionKeyDown` to activate actions on Enter/Space in `BrightnessPanel.jsx:45`.
- Applied `role=\"button\"`, `tabIndex={0}`, and `onKeyDown` to existing interactive click targets:
  - Power icon: `BrightnessPanel.jsx:306`
  - Link-level toggle: `BrightnessPanel.jsx:379`
  - Turn-off-displays icon: `BrightnessPanel.jsx:392`
  - Settings icon: `BrightnessPanel.jsx:402`
  - Update install/dismiss actions: `BrightnessPanel.jsx:423`
- No unrelated refactors or logic changes.

## Regression protection summary
- Added durable manual verification protocol (GUI-constrained):
  1. Focus panel controls with Tab.
  2. Trigger each action with Enter.
  3. Trigger each action with Space.
  4. Confirm mouse behavior remains unchanged.
- This directly guards the reported failure mode (keyboard activation of panel controls).

## Self-review findings
- Non-bug behavior preserved: yes (existing `onClick` kept intact).
- State/cache/desync risk: none introduced (no state model changes).
- Undo/redo semantics: not applicable in this UI path.
- Keyboard/UI flows: improved and now explicit for key activation.
- Platform safety: change is renderer-side React event handling, platform-neutral.
- Smaller patch possible: not meaningfully; this is a single-file, localized fix.

## What broke
Keyboard users could tab through tray panel controls but could not reliably activate several click-only actions using Enter/Space, which blocks accessibility and keyboard-only interaction.

## Root cause
Interactive controls were implemented as div/a with mouse onClick handlers but lacked keyboard activation semantics (tabIndex, key handlers).

## Why this fix is minimal
The patch only updates activation wiring in one component file, reusing existing click handlers and adding a tiny shared keydown helper. No monitor, settings, or brightness logic was changed.

## What I tested
I validated the affected controls now expose keyboard activation paths in code and defined a focused manual verification protocol for Tab + Enter/Space behavior on all touched actions.

## What I intentionally did not change
I did not refactor component structure, replace elements globally, alter styling, or touch any monitor communication/update logic outside the specific keyboard accessibility issue.
