### PR TITLE
Consistent step control for scroll action on flyout slider. (Fixes #1259)

### DIFF
--- a/src/components/Slider.jsx
+++ b/src/components/Slider.jsx
@@ -12,7 +12,7 @@ export default class Slider extends Component {
 
     handleWheel = (event) => {
         if (this.props.scrolling === false) return false;
-        this.setState({ level: this.cap((this.state.level * 1) + Math.round(event.deltaY * -1 * 0.01 * (this.props.scrollAmount ?? 1))) }, this.fireChange)
+        this.setState({ level: this.cap((this.state.level * 1) + Math.sign(event.deltaY) * -1 * (this.props.scrollAmount ?? 1)) }, this.fireChange)
     }
 
     fireChange = () => {


### PR DESCRIPTION
Fix for issue #1259.

Stop using deltaY magnitude; use only sign of deltaY to check if it is a scroll up or scroll down event and then change brightness by the configured scrollFlyoutAmount.

Now scrolling on the slider will work as intended, independent of the Windows Vertical Scrolling setting.