### PR TITLE
Retry transient DDC/CI failures and classify errors by Win32 code

### DIFF
--- a/src/Monitors.js
+++ b/src/Monitors.js
@@ -1171,10 +1171,7 @@ async function checkVCP(monitor, code, skipCacheWrite = false) {
         await wait(parseInt(settings?.checkVCPWaitMS || 20))
         return result
     } catch (e) {
-        let reason = e
-        if(e.message.indexOf("the I2C bus") > 0) reason = "I2C bus error";
-        if(e.message.indexOf("does not support") > 0) reason = "VCP code unsupported";
-        console.log(`Error reading VCP code ${vcpString} for ${monitor}. Reason: ${reason}`)
+        console.log(`Error reading VCP code ${vcpString} for ${monitor}. Reason: ${classifyDDCError(e)}`)
 
         // Since it failed, let's check for an existing value first
         if(vcpCache[monitor]?.["vcp_" + vcpString]) {
@@ -1201,6 +1198,7 @@ async function setVCP(monitor, code, value) {
         }
         return result
     } catch (e) {
+        console.log(`Error setting VCP code ${vcpStr(code)} for ${monitor}. Reason: ${classifyDDCError(e)}`)
         return false
     }
 }
@@ -1439,6 +1437,36 @@ function wait(ms = 2000) {
 
 function vcpStr(code) {
     return `0x${parseInt(code).toString(16).toUpperCase()}`
+}
+
+// Win32 error codes for DDC/CI failures (winerror.h), exposed by
+// node-ddcci as error.win32Code. Message strings from Windows are
+// localized, so failures are classified by code instead.
+const DDC_ERROR_REASONS = {
+    0xC0262580: "I2C not supported",                    // ERROR_GRAPHICS_I2C_NOT_SUPPORTED
+    0xC0262581: "I2C device does not exist",            // ERROR_GRAPHICS_I2C_DEVICE_DOES_NOT_EXIST
+    0xC0262582: "I2C bus error (transmit)",             // ERROR_GRAPHICS_I2C_ERROR_TRANSMITTING_DATA
+    0xC0262583: "I2C bus error (receive)",              // ERROR_GRAPHICS_I2C_ERROR_RECEIVING_DATA
+    0xC0262584: "VCP code unsupported",                 // ERROR_GRAPHICS_DDCCI_VCP_NOT_SUPPORTED
+    0xC0262585: "invalid DDC/CI data",                  // ERROR_GRAPHICS_DDCCI_INVALID_DATA
+    0xC0262586: "invalid timing status byte",           // ERROR_GRAPHICS_DDCCI_MONITOR_RETURNED_INVALID_TIMING_STATUS_BYTE
+    0xC0262587: "invalid capabilities string",          // ERROR_GRAPHICS_MCA_INVALID_CAPABILITIES_STRING
+    0xC0262589: "invalid DDC/CI message command",       // ERROR_GRAPHICS_DDCCI_INVALID_MESSAGE_COMMAND
+    0xC026258A: "invalid DDC/CI message length",        // ERROR_GRAPHICS_DDCCI_INVALID_MESSAGE_LENGTH
+    0xC026258B: "invalid DDC/CI message checksum",      // ERROR_GRAPHICS_DDCCI_INVALID_MESSAGE_CHECKSUM
+    0xC026258C: "invalid physical monitor handle",      // ERROR_GRAPHICS_INVALID_PHYSICAL_MONITOR_HANDLE
+    0xC026258D: "monitor no longer exists"              // ERROR_GRAPHICS_MONITOR_NO_LONGER_EXISTS
+}
+
+function classifyDDCError(e) {
+    const code = e?.win32Code
+    if (code !== undefined && DDC_ERROR_REASONS[code]) {
+        return `${DDC_ERROR_REASONS[code]} (0x${(code >>> 0).toString(16).toUpperCase()})`
+    }
+    // Fallback for errors without an attached code
+    if (e?.message?.indexOf("the I2C bus") > 0) return "I2C bus error";
+    if (e?.message?.indexOf("does not support") > 0) return "VCP code unsupported";
+    return e
 }
 
 testDDCCIMethods = async () => {

--- a/src/Monitors.js
+++ b/src/Monitors.js
@@ -1464,8 +1464,8 @@ function classifyDDCError(e) {
         return `${DDC_ERROR_REASONS[code]} (0x${(code >>> 0).toString(16).toUpperCase()})`
     }
     // Fallback for errors without an attached code
-    if (e?.message?.indexOf("the I2C bus") > 0) return "I2C bus error";
-    if (e?.message?.indexOf("does not support") > 0) return "VCP code unsupported";
+    if (e?.message?.indexOf("the I2C bus") >= 0) return "I2C bus error";
+    if (e?.message?.indexOf("does not support") >= 0) return "VCP code unsupported";
     return e
 }
 

--- a/src/modules/node-ddcci/ddcci.cc
+++ b/src/modules/node-ddcci/ddcci.cc
@@ -139,9 +139,8 @@ cleanMonitorHandles(std::map<std::string, HANDLE> newHandles)
 }
 
 std::string
-getLastErrorString()
+getLastErrorString(DWORD errorCode)
 {
-    DWORD errorCode = GetLastError();
     if (!errorCode) {
         return std::string();
     }
@@ -157,8 +156,77 @@ getLastErrorString()
                     0,
                     NULL);
 
+    if (buf == NULL || size == 0) {
+        return std::string();
+    }
+
     std::string message(buf, size);
+    LocalFree(buf);
     return message;
+}
+
+std::string
+getLastErrorString()
+{
+    return getLastErrorString(GetLastError());
+}
+
+// DDC/CI failures that indicate a garbled message or an I2C bus glitch.
+// These are worth retrying, unlike permanent conditions such as an
+// unsupported VCP code or a monitor that no longer exists.
+bool
+isTransientDdcError(DWORD errorCode)
+{
+    switch (errorCode) {
+        case ERROR_GRAPHICS_I2C_ERROR_TRANSMITTING_DATA:
+        case ERROR_GRAPHICS_I2C_ERROR_RECEIVING_DATA:
+        case ERROR_GRAPHICS_DDCCI_MONITOR_RETURNED_INVALID_TIMING_STATUS_BYTE:
+        case ERROR_GRAPHICS_DDCCI_INVALID_MESSAGE_COMMAND:
+        case ERROR_GRAPHICS_DDCCI_INVALID_MESSAGE_LENGTH:
+        case ERROR_GRAPHICS_DDCCI_INVALID_MESSAGE_CHECKSUM:
+            return true;
+        default:
+            return false;
+    }
+}
+
+// Runs a DDC/CI operation, retrying a couple of times when it fails with
+// a transient error. Returns TRUE on success; on failure, `errorCode`
+// holds the Win32 error of the last attempt.
+template<typename F>
+BOOL
+tryDdcCiOperation(F operation, DWORD& errorCode)
+{
+    const int maxAttempts = 3;
+    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+        if (attempt > 1) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+        if (operation()) {
+            return TRUE;
+        }
+        errorCode = GetLastError();
+        if (!isTransientDdcError(errorCode)) {
+            return FALSE;
+        }
+        std::stringstream hexCode;
+        hexCode << std::hex << std::uppercase << errorCode;
+        d("Transient DDC/CI error. Attempt #" + std::to_string(attempt)
+          + " failed with 0x" + hexCode.str());
+    }
+    return FALSE;
+}
+
+// Throws a JS error carrying the Win32 error code, so callers can
+// classify failures without parsing localized message strings.
+void
+throwDdcCiError(Napi::Env env, const std::string& message, DWORD errorCode)
+{
+    Napi::Error error =
+      Napi::Error::New(env, message + "\n" + getLastErrorString(errorCode));
+    error.Set("win32Code",
+              Napi::Number::New(env, static_cast<double>(errorCode)));
+    throw error;
 }
 
 std::string
@@ -885,10 +953,12 @@ setVCP(const Napi::CallbackInfo& info)
         throw Napi::Error::New(env, "Monitor not found");
     }
 
-    if (!SetVCPFeature(it->second, vcpCode, newValue)) {
-        throw Napi::Error::New(env,
-                               std::string("Failed to set VCP code value\n")
-                                 + getLastErrorString());
+    DWORD errorCode = ERROR_SUCCESS;
+    BOOL ok = tryDdcCiOperation(
+      [&]() { return SetVCPFeature(it->second, vcpCode, newValue); },
+      errorCode);
+    if (!ok) {
+        throwDdcCiError(env, "Failed to set VCP code value", errorCode);
     }
 
     return env.Undefined();
@@ -916,11 +986,15 @@ getVCP(const Napi::CallbackInfo& info)
 
     DWORD currentValue;
     DWORD maxValue;
-    if (!GetVCPFeatureAndVCPFeatureReply(
-          it->second, vcpCode, NULL, &currentValue, &maxValue)) {
-        throw Napi::Error::New(env,
-                               std::string("Failed to get VCP code value\n")
-                                 + getLastErrorString());
+    DWORD errorCode = ERROR_SUCCESS;
+    BOOL ok = tryDdcCiOperation(
+      [&]() {
+          return GetVCPFeatureAndVCPFeatureReply(
+            it->second, vcpCode, NULL, &currentValue, &maxValue);
+      },
+      errorCode);
+    if (!ok) {
+        throwDdcCiError(env, "Failed to get VCP code value", errorCode);
     }
 
     Napi::Array ret = Napi::Array::New(env, 2);
@@ -978,11 +1052,15 @@ getHighLevelBrightness(const Napi::CallbackInfo& info)
     DWORD minValue;
     DWORD currentValue;
     DWORD maxValue;
-    if (!GetMonitorBrightness(
-          it->second, &minValue, &currentValue, &maxValue)) {
-        throw Napi::Error::New(env,
-                               std::string("Failed to get high level brightness\n")
-                                 + getLastErrorString());
+    DWORD errorCode = ERROR_SUCCESS;
+    BOOL ok = tryDdcCiOperation(
+      [&]() {
+          return GetMonitorBrightness(
+            it->second, &minValue, &currentValue, &maxValue);
+      },
+      errorCode);
+    if (!ok) {
+        throwDdcCiError(env, "Failed to get high level brightness", errorCode);
     }
 
     Napi::Array ret = Napi::Array::New(env, 3);
@@ -1014,10 +1092,11 @@ setHighLevelBrightness(const Napi::CallbackInfo& info)
         throw Napi::Error::New(env, "Monitor not found");
     }
 
-    if (!SetMonitorBrightness(it->second, newValue)) {
-        throw Napi::Error::New(env,
-                               std::string("Failed to set high level brightness\n")
-                                 + getLastErrorString());
+    DWORD errorCode = ERROR_SUCCESS;
+    BOOL ok = tryDdcCiOperation(
+      [&]() { return SetMonitorBrightness(it->second, newValue); }, errorCode);
+    if (!ok) {
+        throwDdcCiError(env, "Failed to set high level brightness", errorCode);
     }
 
     return env.Undefined();
@@ -1045,11 +1124,15 @@ getHighLevelContrast(const Napi::CallbackInfo& info)
     DWORD minValue;
     DWORD currentValue;
     DWORD maxValue;
-    if (!GetMonitorContrast(
-          it->second, &minValue, &currentValue, &maxValue)) {
-        throw Napi::Error::New(env,
-                               std::string("Failed to get high level contrast\n")
-                                 + getLastErrorString());
+    DWORD errorCode = ERROR_SUCCESS;
+    BOOL ok = tryDdcCiOperation(
+      [&]() {
+          return GetMonitorContrast(
+            it->second, &minValue, &currentValue, &maxValue);
+      },
+      errorCode);
+    if (!ok) {
+        throwDdcCiError(env, "Failed to get high level contrast", errorCode);
     }
 
     Napi::Array ret = Napi::Array::New(env, 3);
@@ -1081,10 +1164,11 @@ setHighLevelContrast(const Napi::CallbackInfo& info)
         throw Napi::Error::New(env, "Monitor not found");
     }
 
-    if (!SetMonitorContrast(it->second, newValue)) {
-        throw Napi::Error::New(env,
-                               std::string("Failed to set high level contrast\n")
-                                 + getLastErrorString());
+    DWORD errorCode = ERROR_SUCCESS;
+    BOOL ok = tryDdcCiOperation(
+      [&]() { return SetMonitorContrast(it->second, newValue); }, errorCode);
+    if (!ok) {
+        throwDdcCiError(env, "Failed to set high level contrast", errorCode);
     }
 
     return env.Undefined();


### PR DESCRIPTION
## Problem

1. A single I2C glitch during a VCP operation fails it outright. For reads, Twinkle Tray falls back to cached values; for writes there is no fallback — a brightness slider change can be **silently dropped** (`setVCP` in Monitors.js caught the error and returned false without logging).
2. `checkVCP` classifies failures by matching substrings like `"the I2C bus"` in the Windows error message. `FormatMessage` returns **localized** strings, so on non-English Windows these checks never match and every failure logs as an unclassified error object.

## Changes

**node-ddcci (`ddcci.cc`)**
- VCP get/set and high-level brightness/contrast get/set now retry up to 2 extra times (50ms apart) when the failure is a *transient* bus/message error: `ERROR_GRAPHICS_I2C_ERROR_TRANSMITTING_DATA`, `..._RECEIVING_DATA`, `ERROR_GRAPHICS_DDCCI_INVALID_MESSAGE_COMMAND/LENGTH/CHECKSUM`, `..._INVALID_TIMING_STATUS_BYTE`. Permanent conditions (VCP unsupported, monitor no longer exists, invalid handle) fail immediately, exactly as before.
- Errors thrown to JS now carry the raw Win32 error code as `error.win32Code`, so callers can classify failures without parsing localized text.
- `getLastErrorString`: the `FormatMessage` buffer is now freed (`LocalFree`) and a null result no longer constructs a string from a null pointer. Added an explicit-code overload.

**Monitors.js**
- Failures are classified via a `win32Code` → reason table (values from `winerror.h`); the old message-substring checks remain only as a fallback for errors without a code.
- Failed VCP writes now log the monitor, code, and classified reason.

## Notes
- Retry cadence: worst case adds ~100ms to a genuinely failing operation; successful operations are unaffected.
- No API/signature changes — `getVCP`/`setVCP` behave identically on success.

## Verification
- `ddcci.cc` compiles cleanly (node-gyp rebuild, MSVC x64).
- `Monitors.js` passes syntax check; error-table key lookup verified against numeric `win32Code` values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)