### PR TITLE
Instant internal display sync via WMI brightness change events

### DIFF
--- a/src/Monitors.js
+++ b/src/Monitors.js
@@ -86,6 +86,7 @@ process.on('message', async (data) => {
             ddcci._clearDisplayCache()
         } else if (data.type === "wmi-bridge-ok") {
             canUseWmiBridge = data.value
+            if (canUseWmiBridge) startWmiBrightnessWatcher();
         } else if (data.type === "getVCP") {
             getDDCCI()
             const vcp = await checkVCP(data.monitor, data.code)
@@ -675,6 +676,47 @@ getHDRDisplays = async (monitors) => {
     }
 
     return monitors
+}
+
+// Watches for internal display brightness changes made outside this
+// process (brightness keys, Windows quick settings, adaptive brightness)
+// so they show up without waiting for the next polled refresh.
+let wmiBrightnessWatcherStarted = false
+function startWmiBrightnessWatcher() {
+    if (wmiBrightnessWatcherStarted || settings?.disableWMI) return false;
+    try {
+        const ok = wmibridge.startBrightnessWatcher(handleWmiBrightnessEvent)
+        wmiBrightnessWatcherStarted = (ok !== false)
+        if (wmiBrightnessWatcherStarted) console.log("Started WMI brightness watcher.");
+    } catch (e) {
+        console.log("Couldn't start WMI brightness watcher", e)
+    }
+    return wmiBrightnessWatcherStarted
+}
+
+function handleWmiBrightnessEvent(event) {
+    try {
+        if (!monitors) return false;
+        const brightness = parseInt(event?.Brightness)
+        if (isNaN(brightness) || brightness < 0) return false;
+
+        const wmiMonitor = Object.values(monitors).find(mon => mon.type === "wmi")
+        if (!wmiMonitor) return false;
+
+        // Skip no-op updates, including echoes of this process's own writes.
+        if (wmiMonitor.brightness === brightness && wmiMonitor.brightnessRaw === brightness) return false;
+
+        wmiMonitor.brightness = brightness
+        wmiMonitor.brightnessRaw = brightness
+        if (wmiMonitor.brightnessValues) wmiMonitor.brightnessValues[0] = brightness;
+
+        process.send({
+            type: 'wmiBrightnessChanged',
+            monitor: deepCopy(wmiMonitor)
+        })
+    } catch (e) {
+        console.log("Error handling WMI brightness event", e)
+    }
 }
 
 let wmiFailed = false

--- a/src/electron.js
+++ b/src/electron.js
@@ -173,6 +173,24 @@ let monitorsThread = {
 }
 let monitorsThreadReal
 let monitorsEventEmitter = new EventEmitter()
+
+// Instant updates when the internal display's brightness changes outside
+// the app (brightness keys, Windows quick settings, adaptive brightness).
+monitorsEventEmitter.on("wmiBrightnessChanged", (data) => {
+  try {
+    const updated = data?.monitor
+    if (!updated?.key || !monitors[updated.key]) return;
+    if (pausedMonitorUpdates) return; // Avoid judder while the user is interacting
+    if (monitors[updated.key].brightness === updated.brightness) return;
+
+    monitors[updated.key].brightness = updated.brightness
+    monitors[updated.key].brightnessRaw = updated.brightnessRaw
+    setTrayPercent()
+    sendToAllWindows('monitors-updated', monitors)
+  } catch (e) {
+    console.log("Error handling WMI brightness change event", e)
+  }
+})
 let monitorsThreadReady = false
 let monitorsThreadStarting = false
 let monitorsThreadFailed = false

--- a/src/electron.js
+++ b/src/electron.js
@@ -181,10 +181,14 @@ monitorsEventEmitter.on("wmiBrightnessChanged", (data) => {
     const updated = data?.monitor
     if (!updated?.key || !monitors[updated.key]) return;
     if (pausedMonitorUpdates) return; // Avoid judder while the user is interacting
-    if (monitors[updated.key].brightness === updated.brightness) return;
+    const monitor = monitors[updated.key]
+    const brightnessRaw = updated.brightnessRaw
+    if (!Number.isFinite(brightnessRaw)) return;
+    const brightness = normalizeBrightness(brightnessRaw, true, monitor.min, monitor.max, monitor.calibration)
+    if (monitor.brightness === brightness && monitor.brightnessRaw === brightnessRaw) return;
 
-    monitors[updated.key].brightness = updated.brightness
-    monitors[updated.key].brightnessRaw = updated.brightnessRaw
+    monitor.brightness = brightness
+    monitor.brightnessRaw = brightnessRaw
     setTrayPercent()
     sendToAllWindows('monitors-updated', monitors)
   } catch (e) {

--- a/src/modules/wmi-bridge/index.js
+++ b/src/modules/wmi-bridge/index.js
@@ -26,6 +26,25 @@ class WMIBridge {
             return { failed: true }
         }
     }
+    // Calls back with { InstanceName, Brightness, Active } whenever the
+    // internal display's brightness changes (including changes made
+    // outside this process).
+    startBrightnessWatcher = (callback) => {
+        let ok = false
+        try {
+            ok = addon.startBrightnessWatcher((event) => {
+                try { callback(event) } catch(e) { console.log(e) }
+            })
+        } catch(e) { console.log(e) }
+        return ok
+    }
+    stopBrightnessWatcher = () => {
+        let ok = false
+        try {
+            ok = addon.stopBrightnessWatcher()
+        } catch(e) { console.log(e) }
+        return ok
+    }
 }
 
 module.exports = new WMIBridge();

--- a/src/modules/wmi-bridge/wmi-bridge.cc
+++ b/src/modules/wmi-bridge/wmi-bridge.cc
@@ -5,6 +5,10 @@
 #include <string>
 #include <mutex>
 #include <cmath>
+#include <thread>
+#include <atomic>
+#include <memory>
+#include <chrono>
 #include <WbemCli.h>
 #include <comdef.h>
 #include <wrl/client.h>
@@ -420,6 +424,179 @@ Napi::Boolean setBrightness(const Napi::CallbackInfo& info)
     return Napi::Boolean::New(env, setWMIBrightness(static_cast<int>(requestedLevel)));
 }
 
+//
+// Brightness change notifications (WmiMonitorBrightnessEvent)
+//
+
+struct BrightnessEvent {
+    std::string instanceName;
+    int brightness = -1;
+    bool active = true;
+};
+
+void callJsBrightnessEvent(Napi::Env env,
+                           Napi::Function callback,
+                           std::nullptr_t* /*context*/,
+                           BrightnessEvent* event)
+{
+    if (env != nullptr && callback != nullptr && event != nullptr) {
+        Napi::Object out = Napi::Object::New(env);
+        out.Set("InstanceName", Napi::String::New(env, event->instanceName));
+        out.Set("Brightness", Napi::Number::New(env, event->brightness));
+        out.Set("Active", Napi::Boolean::New(env, event->active));
+        callback.Call({ out });
+    }
+    delete event;
+}
+
+using BrightnessEventCallback =
+  Napi::TypedThreadSafeFunction<std::nullptr_t, BrightnessEvent, callJsBrightnessEvent>;
+
+std::mutex watcherMutex;
+std::shared_ptr<std::atomic<bool>> watcherStopFlag;
+
+int readWmiEventInt(IWbemClassObject* obj, const wchar_t* name, int fallback)
+{
+    VARIANT value;
+    VariantInit(&value);
+    if (FAILED(obj->Get(name, 0, &value, NULL, NULL))) {
+        VariantClear(&value);
+        return fallback;
+    }
+
+    VARIANT asInt;
+    VariantInit(&asInt);
+    HRESULT hr = VariantChangeType(&asInt, &value, 0, VT_I4);
+    VariantClear(&value);
+    if (FAILED(hr)) {
+        VariantClear(&asInt);
+        return fallback;
+    }
+
+    int result = asInt.lVal;
+    VariantClear(&asInt);
+    return result;
+}
+
+void brightnessWatcherThreadProc(BrightnessEventCallback callback,
+                                 std::shared_ptr<std::atomic<bool>> shouldStop)
+{
+    ComScope com;
+    if (!com.isUsable() || !initializeWmiSecurity()) {
+        callback.Release();
+        return;
+    }
+
+    while (!shouldStop->load()) {
+        ComPtr<IWbemLocator> locator;
+        ComPtr<IWbemServices> service;
+        ComPtr<IEnumWbemClassObject> enumerator;
+
+        HRESULT hr = E_FAIL;
+        if (connectToWmi(locator, service)) {
+            hr = service->ExecNotificationQuery(
+              L"WQL",
+              L"SELECT * FROM WmiMonitorBrightnessEvent",
+              WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY,
+              NULL,
+              enumerator.GetAddressOf());
+        }
+
+        if (FAILED(hr) || !enumerator) {
+            // The event class doesn't exist on systems without a
+            // WMI-controllable display, so there is nothing to watch.
+            if (hr == WBEM_E_INVALID_CLASS || hr == WBEM_E_INVALID_QUERY
+                || hr == WBEM_E_NOT_SUPPORTED || hr == WBEM_E_NOT_FOUND) {
+                break;
+            }
+            // Otherwise (e.g. the WMI service is restarting), wait and retry.
+            for (int i = 0; i < 50 && !shouldStop->load(); i++) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            }
+            continue;
+        }
+
+        while (!shouldStop->load()) {
+            ComPtr<IWbemClassObject> event;
+            ULONG returned = 0;
+            hr = enumerator->Next(1000, 1, event.GetAddressOf(), &returned);
+            if (hr == WBEM_S_TIMEDOUT) {
+                continue;
+            }
+            if (FAILED(hr) || returned == 0 || !event) {
+                // Connection died. Reconnect via the outer loop.
+                break;
+            }
+
+            VARIANT instanceName;
+            VariantInit(&instanceName);
+            HRESULT instanceResult =
+              event->Get(L"InstanceName", 0, &instanceName, NULL, NULL);
+            std::string instance;
+            if (SUCCEEDED(instanceResult) && instanceName.vt == VT_BSTR) {
+                instance = bstr_to_str(instanceName.bstrVal);
+            }
+            VariantClear(&instanceName);
+
+            BrightnessEvent* data = new BrightnessEvent();
+            data->instanceName = instance;
+            data->brightness = readWmiEventInt(event.Get(), L"Brightness", -1);
+            data->active = (readWmiEventInt(event.Get(), L"Active", 1) != 0);
+
+            if (callback.BlockingCall(data) != napi_ok) {
+                // The environment is shutting down.
+                delete data;
+                shouldStop->store(true);
+                break;
+            }
+        }
+    }
+
+    callback.Release();
+}
+
+Napi::Boolean startBrightnessWatcher(const Napi::CallbackInfo& info)
+{
+    Napi::Env env = info.Env();
+    if (info.Length() < 1 || !info[0].IsFunction()) {
+        return Napi::Boolean::New(env, false);
+    }
+
+    std::lock_guard<std::mutex> lock(watcherMutex);
+    if (watcherStopFlag && !watcherStopFlag->load()) {
+        // Already running
+        return Napi::Boolean::New(env, true);
+    }
+
+    auto stopFlag = std::make_shared<std::atomic<bool>>(false);
+    BrightnessEventCallback callback = BrightnessEventCallback::New(
+      env, info[0].As<Napi::Function>(), "wmiBrightnessWatcher", 0, 1);
+    // The watcher must not keep the process alive on its own.
+    callback.Unref(env);
+
+    try {
+        // The thread owns its copy of the callback and releases it on exit.
+        std::thread(brightnessWatcherThreadProc, callback, stopFlag).detach();
+    } catch (...) {
+        callback.Release();
+        return Napi::Boolean::New(env, false);
+    }
+
+    watcherStopFlag = stopFlag;
+    return Napi::Boolean::New(env, true);
+}
+
+Napi::Boolean stopBrightnessWatcher(const Napi::CallbackInfo& info)
+{
+    Napi::Env env = info.Env();
+    std::lock_guard<std::mutex> lock(watcherMutex);
+    if (!watcherStopFlag || watcherStopFlag->load()) {
+        return Napi::Boolean::New(env, false);
+    }
+    watcherStopFlag->store(true);
+    return Napi::Boolean::New(env, true);
+}
+
 Napi::Object getBrightness(const Napi::CallbackInfo& info)
 {
     try {
@@ -446,6 +623,10 @@ Napi::Object Init(Napi::Env env, Napi::Object exports)
                 Napi::Function::New(env, getBrightness));
     exports.Set(Napi::String::New(env, "getMonitors"),
                 Napi::Function::New(env, getMonitors));
+    exports.Set(Napi::String::New(env, "startBrightnessWatcher"),
+                Napi::Function::New(env, startBrightnessWatcher));
+    exports.Set(Napi::String::New(env, "stopBrightnessWatcher"),
+                Napi::Function::New(env, stopBrightnessWatcher));
 
     return exports;
 }

--- a/src/modules/wmi-bridge/wmi-bridge.cc
+++ b/src/modules/wmi-bridge/wmi-bridge.cc
@@ -483,6 +483,7 @@ void brightnessWatcherThreadProc(BrightnessEventCallback callback,
 {
     ComScope com;
     if (!com.isUsable() || !initializeWmiSecurity()) {
+        shouldStop->store(true);
         callback.Release();
         return;
     }
@@ -552,6 +553,7 @@ void brightnessWatcherThreadProc(BrightnessEventCallback callback,
         }
     }
 
+    shouldStop->store(true);
     callback.Release();
 }
 


### PR DESCRIPTION
## Problem

When laptop brightness changes outside Twinkle Tray — Fn keys, Windows quick settings, adaptive brightness, power plans — the slider only catches up on the next polled refresh (up to 60 seconds with default settings). Windows raises `WmiMonitorBrightnessEvent` in `root\wmi` for exactly this; subscribing to it gives instant updates with zero polling cost.

## Changes

**wmi-bridge (native)**
- New `startBrightnessWatcher(callback)` / `stopBrightnessWatcher()` exports.
- A detached worker thread issues `ExecNotificationQuery("SELECT * FROM WmiMonitorBrightnessEvent")` (semisynchronous, 1s `Next()` timeout) and forwards `{ InstanceName, Brightness, Active }` to JS via a `TypedThreadSafeFunction`.
- Lifecycle handling:
  - Reconnects with backoff if the WMI connection drops (e.g. service restart).
  - Exits permanently when the event class doesn't exist — desktops without a WMI-controllable display don't spin.
  - The threadsafe function is unref'd so the watcher never keeps the process alive; environment shutdown aborts the callback queue and the thread exits on its own.
  - Start is idempotent; stop/start races are handled with a per-thread stop flag.

**Monitors.js**
- Starts the watcher once the main process confirms the bridge is healthy (`wmi-bridge-ok`), unless `disableWMI` is set.
- On event: updates the tracked WMI monitor and forwards a `wmiBrightnessChanged` message. No-op updates — including echoes of writes made by this process — are dropped, so there's no feedback loop.

**electron.js**
- Applies the update to the `monitors` state, refreshes the tray percentage, and pushes `monitors-updated` to windows. Skipped while monitor updates are paused (user dragging a slider) to avoid judder.

## Verification
- Compiles cleanly (node-gyp rebuild, MSVC x64); all JS passes syntax checks.
- Live-tested the addon on a desktop without an internal display: watcher starts, double-start is idempotent, stop returns true then false, and the process exits promptly (no dangling thread / event-loop pin).
- Event-path (laptop) behavior needs a hardware test: press brightness keys with the panel open and confirm the slider moves immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)