### PR TITLE
Detect crashes during DDC/CI probing and auto-downgrade validation

### DIFF
--- a/src/Monitors.js
+++ b/src/Monitors.js
@@ -189,6 +189,18 @@ function ddcSentinelEnd() {
     } catch (e) { }
 }
 
+function withDDCSentinel(stage, monitor, operation) {
+    ddcSentinelStart(stage, monitor)
+    try {
+        return operation()
+    } finally {
+        // A native crash never reaches this point, leaving evidence for the
+        // next worker. Ordinary JavaScript/native errors do, so don't treat
+        // them as crashes on the next startup.
+        ddcSentinelEnd()
+    }
+}
+
 // A graceful exit mid-operation isn't crash evidence.
 process.on('exit', ddcSentinelEnd)
 
@@ -859,9 +871,9 @@ getFeaturesDDC = (ddcciMethod = "accurate") => {
             await wait(10)
 
             // Sometimes the handles returned are NULL, so we should try again.
-            ddcSentinelStart("refresh")
-            let tmpDdcciMonitors = ddcci.getAllMonitors(ddcciMethod, true, !settings.disableHighLevel)
-            ddcSentinelEnd()
+            let tmpDdcciMonitors = withDDCSentinel("refresh", false, () =>
+                ddcci.getAllMonitors(ddcciMethod, true, !settings.disableHighLevel)
+            )
             if(tmpDdcciMonitors) {
                 let doRetry = false
                 for(const monitor of tmpDdcciMonitors) {
@@ -873,9 +885,9 @@ getFeaturesDDC = (ddcciMethod = "accurate") => {
                 if(doRetry) {
                     console.log(`DDC/CI results contain a null handle (${doRetry?.deviceKey}). Trying again.`)
                     await wait(200)
-                    ddcSentinelStart("refresh")
-                    tmpDdcciMonitors = ddcci.getAllMonitors(ddcciMethod, true, !settings.disableHighLevel)
-                    ddcSentinelEnd()
+                    tmpDdcciMonitors = withDDCSentinel("refresh", false, () =>
+                        ddcci.getAllMonitors(ddcciMethod, true, !settings.disableHighLevel)
+                    )
                     for(const monitor of tmpDdcciMonitors) {
                         if(monitor.handleIsValid === false) {
                             console.log(`DDC/CI results still contain a null handle (${doRetry?.deviceKey}). Continuing anyway.`)
@@ -939,9 +951,9 @@ checkMonitorFeatures = async (monitor, skipCache = false, ddcciMethod = "accurat
                 if(unstableDDC[monitor]) {
                     console.log(`Skipping capabilities report for ${monitor} due to crash evidence from a previous session.`)
                 } else if(ddcciMethod === "accurate" && !monitorReports[monitor]) {
-                    ddcSentinelStart("capabilities", monitor)
-                    const reportRaw = ddcci.getCapabilitiesRaw(monitor)
-                    ddcSentinelEnd()
+                    const reportRaw = withDDCSentinel("capabilities", monitor, () =>
+                        ddcci.getCapabilitiesRaw(monitor)
+                    )
                     if(reportRaw) {
                         monitorReportsRaw[monitor] = reportRaw
                         const report = ddcci._parseCapabilitiesString(reportRaw)
@@ -1572,9 +1584,9 @@ testDDCCIMethods = async () => {
         getDDCCI()
 
         let startTime = process.hrtime.bigint()
-        ddcSentinelStart("method-test")
-        const accurateResults = ddcci.getAllMonitors("accurate", false)
-        ddcSentinelEnd()
+        const accurateResults = withDDCSentinel("method-test", false, () =>
+            ddcci.getAllMonitors("accurate", false)
+        )
         const accurateIDs = []
         const accurateFeatures = []
         for(const monitor of accurateResults) {
@@ -1592,9 +1604,9 @@ testDDCCIMethods = async () => {
         ddcci._clearDisplayCache()
     
         startTime = process.hrtime.bigint()
-        ddcSentinelStart("method-test")
-        const fastResults = ddcci.getAllMonitors("fast", false)
-        ddcSentinelEnd()
+        const fastResults = withDDCSentinel("method-test", false, () =>
+            ddcci.getAllMonitors("fast", false)
+        )
         const fastIDs = []
         const fastFeatures = []
         for(const monitor of fastResults) {

--- a/src/Monitors.js
+++ b/src/Monitors.js
@@ -107,7 +107,8 @@ process.on('message', async (data) => {
                     monitorReports,
                     monitorReportsRaw,
                     lastRefresh,
-                    settings
+                    settings,
+                    unstableDDC
                 }
             })
         }
@@ -118,6 +119,78 @@ process.on('message', async (data) => {
 
 let isDev = (process.argv.indexOf("--isdev=true") >= 0)
 let skipTest = (process.argv.indexOf("--skiptest=true") >= 0)
+
+//
+// Crash evidence for risky DDC/CI operations.
+//
+// Capabilities reads and DDC probing can hang or crash the whole process
+// (or machine) on misbehaving monitors/drivers. A sentinel file is written
+// before each risky operation and removed afterwards. If a sentinel
+// survives to the next startup, the previous session died mid-operation,
+// and DDC/CI validation is downgraded to the "fast" method (which never
+// requests capabilities strings) instead of hanging again on every start.
+//
+const sentinelFs = require('fs')
+const sentinelPathModule = require('path')
+const dataPathArg = process.argv.find(arg => arg.indexOf("--datapath=") === 0)
+const sentinelDir = (dataPathArg ? dataPathArg.substring(11) : require('os').tmpdir())
+const sentinelPath = sentinelPathModule.join(sentinelDir, "ddc-probe.lock")
+const unstableDDCPath = sentinelPathModule.join(sentinelDir, "ddc-unstable.json")
+
+let unstableDDC = {}
+
+function writeUnstableDDC() {
+    try {
+        sentinelFs.writeFileSync(unstableDDCPath, JSON.stringify(unstableDDC))
+    } catch (e) {
+        console.log("Couldn't save unstable DDC list", e)
+    }
+}
+
+function checkForDDCCrashEvidence() {
+    try {
+        try {
+            if (sentinelFs.existsSync(unstableDDCPath)) {
+                unstableDDC = JSON.parse(sentinelFs.readFileSync(unstableDDCPath, "utf8")) || {}
+            }
+        } catch (e) {
+            unstableDDC = {}
+        }
+
+        if (!sentinelFs.existsSync(sentinelPath)) return;
+
+        let evidence = {}
+        try {
+            evidence = JSON.parse(sentinelFs.readFileSync(sentinelPath, "utf8")) || {}
+        } catch (e) { }
+        sentinelFs.unlinkSync(sentinelPath)
+
+        console.log("\x1b[41mA previous session died during a DDC/CI operation. Downgrading DDC/CI validation to \"fast\".\x1b[0m", evidence)
+        unstableDDC.downgraded = { time: Date.now(), stage: evidence.stage, monitor: evidence.monitor }
+        if (evidence.monitor) {
+            unstableDDC[evidence.monitor] = { time: Date.now(), stage: evidence.stage }
+        }
+        writeUnstableDDC()
+    } catch (e) {
+        console.log("Error checking DDC crash evidence", e)
+    }
+}
+checkForDDCCrashEvidence()
+
+function ddcSentinelStart(stage, monitor = false) {
+    try {
+        sentinelFs.writeFileSync(sentinelPath, JSON.stringify({ stage, monitor, time: Date.now() }))
+    } catch (e) { }
+}
+
+function ddcSentinelEnd() {
+    try {
+        sentinelFs.unlinkSync(sentinelPath)
+    } catch (e) { }
+}
+
+// A graceful exit mid-operation isn't crash evidence.
+process.on('exit', ddcSentinelEnd)
 
 let monitors = false
 let monitorNames = []
@@ -463,8 +536,12 @@ function determineDDCCIMethod() {
     const savedMethod = settings?.preferredDDCCIMethod
     const ddcciMethodValues = ["fast", "accurate", "no-validation", "legacy"]
     if(savedMethod && ddcciMethodValues.indexOf(savedMethod) >= 0) {
+        // An explicit user preference wins over the crash downgrade.
         ddcciMethod = savedMethod
-    } 
+    } else if (unstableDDC.downgraded && ddcciMethod === "accurate") {
+        console.log("Using \"fast\" DDC/CI validation due to crash evidence from a previous session.")
+        ddcciMethod = "fast"
+    }
     return ddcciMethod
 }
 
@@ -782,7 +859,9 @@ getFeaturesDDC = (ddcciMethod = "accurate") => {
             await wait(10)
 
             // Sometimes the handles returned are NULL, so we should try again.
+            ddcSentinelStart("refresh")
             let tmpDdcciMonitors = ddcci.getAllMonitors(ddcciMethod, true, !settings.disableHighLevel)
+            ddcSentinelEnd()
             if(tmpDdcciMonitors) {
                 let doRetry = false
                 for(const monitor of tmpDdcciMonitors) {
@@ -794,7 +873,9 @@ getFeaturesDDC = (ddcciMethod = "accurate") => {
                 if(doRetry) {
                     console.log(`DDC/CI results contain a null handle (${doRetry?.deviceKey}). Trying again.`)
                     await wait(200)
+                    ddcSentinelStart("refresh")
                     tmpDdcciMonitors = ddcci.getAllMonitors(ddcciMethod, true, !settings.disableHighLevel)
+                    ddcSentinelEnd()
                     for(const monitor of tmpDdcciMonitors) {
                         if(monitor.handleIsValid === false) {
                             console.log(`DDC/CI results still contain a null handle (${doRetry?.deviceKey}). Continuing anyway.`)
@@ -855,8 +936,12 @@ checkMonitorFeatures = async (monitor, skipCache = false, ddcciMethod = "accurat
 
             // Detect valid VCP codes for display if not already available
             try {
-                if(ddcciMethod === "accurate" && !monitorReports[monitor]) {
+                if(unstableDDC[monitor]) {
+                    console.log(`Skipping capabilities report for ${monitor} due to crash evidence from a previous session.`)
+                } else if(ddcciMethod === "accurate" && !monitorReports[monitor]) {
+                    ddcSentinelStart("capabilities", monitor)
                     const reportRaw = ddcci.getCapabilitiesRaw(monitor)
+                    ddcSentinelEnd()
                     if(reportRaw) {
                         monitorReportsRaw[monitor] = reportRaw
                         const report = ddcci._parseCapabilitiesString(reportRaw)
@@ -1476,12 +1561,20 @@ testDDCCIMethods = async () => {
             console.log("Skipping DDC/CI test...")
             return false
         }
+        if(unstableDDC.downgraded) {
+            // The accurate test reads capabilities strings, which is what
+            // likely killed the previous session. Don't try it again.
+            console.log("Skipping DDC/CI test due to crash evidence from a previous session.")
+            return true
+        }
 
         console.log("Testing DDC/CI methods...")
         getDDCCI()
-    
+
         let startTime = process.hrtime.bigint()
+        ddcSentinelStart("method-test")
         const accurateResults = ddcci.getAllMonitors("accurate", false)
+        ddcSentinelEnd()
         const accurateIDs = []
         const accurateFeatures = []
         for(const monitor of accurateResults) {
@@ -1499,7 +1592,9 @@ testDDCCIMethods = async () => {
         ddcci._clearDisplayCache()
     
         startTime = process.hrtime.bigint()
+        ddcSentinelStart("method-test")
         const fastResults = ddcci.getAllMonitors("fast", false)
+        ddcSentinelEnd()
         const fastIDs = []
         const fastFeatures = []
         for(const monitor of fastResults) {

--- a/src/electron.js
+++ b/src/electron.js
@@ -183,7 +183,7 @@ function startMonitorThread({ allowWhileWindowsIdle = false } = {}) {
   monitorsThreadStarting = true
   console.log("Starting monitor thread")
   const skipTest = (settings.preferredDDCCIMethod == "auto" ? false : true)
-  monitorsThreadReal = fork(path.join(__dirname, 'Monitors.js'), ["--isdev=" + isDev, "--apppath=" + app.getAppPath(), "--skiptest=" + skipTest], { silent: false })
+  monitorsThreadReal = fork(path.join(__dirname, 'Monitors.js'), ["--isdev=" + isDev, "--apppath=" + app.getAppPath(), "--skiptest=" + skipTest, "--datapath=" + app.getPath("userData")], { silent: false })
   monitorsThreadReal.on("message", (data) => {
     if (data?.type) {
       if (data.type === "ready") {


### PR DESCRIPTION
## Problem

Capabilities-string reads are the most dangerous DDC/CI operation — several seconds of I²C traffic that some monitor/driver combinations respond to by hanging the thread or worse. The monitor thread recovers from hangs, but nothing remembers *why* it died, so the same monitor gets probed the same way on every startup.

## Approach

Write-ahead crash evidence:

1. Before each risky DDC/CI operation, the monitor thread writes `ddc-probe.lock` (in `userData`) naming the stage (`capabilities` / `refresh` / `method-test`) and the monitor being probed, when known. The file is deleted when the operation completes (and on graceful process exit, so normal shutdowns don't count).
2. If a sentinel file survives to the next monitor-thread start, the previous session died mid-operation. The thread then:
   - downgrades DDC/CI validation to **fast** (which never requests capabilities strings) for future auto-selected sessions,
   - permanently skips capabilities reads for the specific monitor named in the evidence,
   - skips the startup accurate-vs-fast benchmark (it reads capabilities too).
3. The downgrade is persisted in `ddc-unstable.json` and included in the debug report for diagnosis.

## Escape hatches

- An explicit `preferredDDCCIMethod` setting always wins — a user who deliberately selects "accurate" gets accurate.
- Because thread restarts also run the check, a hang recovered by the in-session thread watchdog triggers the downgrade immediately, not just after an app restart.

## Notes

- `electron.js` passes `--datapath=<userData>` to the monitor thread; without it (e.g. dev harnesses) the sentinel falls back to the OS temp dir.
- False-positive window: killing the app at the exact moment a normal refresh is probing would count as evidence. The consequence is mild (fast validation, which the startup benchmark selects on most systems anyway) and visible in logs/report.

## Verification
- Syntax checks pass. Sentinel write/clear paths reviewed against every `ddcci.getAllMonitors`/`getCapabilitiesRaw` call site (grep-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)