### PR TITLE
Add WinRT DisplayMonitor as a display info enrichment source

### DIFF
--- a/src/Monitors.js
+++ b/src/Monitors.js
@@ -13,6 +13,7 @@ let lastRefresh = {}
 let lastWin32 = {}
 let lastWMI = {}
 let lastHDR = {}
+let lastWinRT = {}
 
 function deepCopy(obj) {
     try {
@@ -107,6 +108,7 @@ process.on('message', async (data) => {
                     monitorReports,
                     monitorReportsRaw,
                     lastRefresh,
+                    lastWinRT,
                     settings
                 }
             })
@@ -804,6 +806,7 @@ getMonitorsWinRT = async () => {
     } catch (e) {
         console.log("getMonitorsWinRT: Failed to get display info.", e)
     }
+    lastWinRT = deepCopy(foundMonitors)
     return foundMonitors
 }
 

--- a/src/Monitors.js
+++ b/src/Monitors.js
@@ -771,8 +771,10 @@ getMonitorsWinRT = async () => {
     const foundMonitors = {}
     try {
         const displayInfo = getWinRTDisplayInfo()
-        if (!displayInfo?.getDisplayMonitors) return foundMonitors;
-
+        if (!displayInfo?.getDisplayMonitors) {
+            lastWinRT = deepCopy(foundMonitors)
+            return foundMonitors;
+        }
         const displays = displayInfo.getDisplayMonitors()
         for (const display of displays) {
             if (!display?.deviceInterfaceId) continue;

--- a/src/Monitors.js
+++ b/src/Monitors.js
@@ -50,6 +50,7 @@ process.on('message', async (data) => {
             if (settings?.disableWMIC) wmicUnavailable = true;
             if (settings?.disableWMI) wmiFailed = true;
             if (settings?.disableWin32) win32Failed = true;
+            if (settings?.disableWinRT) winrtDisplayInfoFailed = true;
 
         } else if (data.type === "ddcBrightnessVCPs") {
             ddcBrightnessVCPs = data.ddcBrightnessVCPs
@@ -298,23 +299,27 @@ getAllMonitors = async (ddcciMethod = "default") => {
     }
 
     // Extra display details via WinRT (internal/external, physical size)
-    try {
-        startTime = process.hrtime.bigint()
-        const monitorsWinRT = await getMonitorsWinRT()
-        console.log(`getMonitorsWinRT() Total: ${(startTime - process.hrtime.bigint()) / BigInt(-1000000)}ms`)
+    if (!winrtDisplayInfoFailed) {
+        try {
+            startTime = process.hrtime.bigint()
+            const monitorsWinRT = await getMonitorsWinRT()
+            console.log(`getMonitorsWinRT() Total: ${(startTime - process.hrtime.bigint()) / BigInt(-1000000)}ms`)
 
-        for (const hwid2 in monitorsWinRT) {
-            const monitor = monitorsWinRT[hwid2]
-            // Only use the WinRT name when no other source provided one
-            const winrtName = monitor.winrtName
-            delete monitor.winrtName
-            if (winrtName && !foundMonitors[hwid2]?.name) {
-                monitor.name = winrtName
+            for (const hwid2 in monitorsWinRT) {
+                const monitor = monitorsWinRT[hwid2]
+                // Only use the WinRT name when no other source provided one
+                const winrtName = monitor.winrtName
+                delete monitor.winrtName
+                if (winrtName && !foundMonitors[hwid2]?.name) {
+                    monitor.name = winrtName
+                }
+                updateDisplay(foundMonitors, hwid2, monitor)
             }
-            updateDisplay(foundMonitors, hwid2, monitor)
+        } catch (e) {
+            console.log("\x1b[41m" + "getMonitorsWinRT() failed!" + "\x1b[0m", e)
         }
-    } catch (e) {
-        console.log("\x1b[41m" + "getMonitorsWinRT() failed!" + "\x1b[0m", e)
+    } else {
+        console.log("getMonitorsWinRT() skipped due to previous failure.")
     }
 
     // List Apple Studio displays

--- a/src/Monitors.js
+++ b/src/Monitors.js
@@ -295,6 +295,26 @@ getAllMonitors = async (ddcciMethod = "default") => {
         console.log("getMonitorsWin32() skipped due to previous failure.")
     }
 
+    // Extra display details via WinRT (internal/external, physical size)
+    try {
+        startTime = process.hrtime.bigint()
+        const monitorsWinRT = await getMonitorsWinRT()
+        console.log(`getMonitorsWinRT() Total: ${(startTime - process.hrtime.bigint()) / BigInt(-1000000)}ms`)
+
+        for (const hwid2 in monitorsWinRT) {
+            const monitor = monitorsWinRT[hwid2]
+            // Only use the WinRT name when no other source provided one
+            const winrtName = monitor.winrtName
+            delete monitor.winrtName
+            if (winrtName && !foundMonitors[hwid2]?.name) {
+                monitor.name = winrtName
+            }
+            updateDisplay(foundMonitors, hwid2, monitor)
+        }
+    } catch (e) {
+        console.log("\x1b[41m" + "getMonitorsWinRT() failed!" + "\x1b[0m", e)
+    }
+
     // List Apple Studio displays
     if (!appleStudioUnavailable) {
         try {
@@ -307,7 +327,7 @@ getAllMonitors = async (ddcciMethod = "default") => {
     } else {
         console.log("getStudioDisplay() skipped due to previous failure.")
     }
-    
+
 
     // DDC/CI Brightness + Features
     try {
@@ -722,6 +742,69 @@ getMonitorsWMI = () => {
         lastWMI = deepCopy(foundMonitors)
         resolve(foundMonitors)
     })
+}
+
+// Extra display details via WinRT DisplayMonitor: definitive
+// internal/external classification, physical size, native resolution,
+// and a display name that doesn't depend on the WMI/Win32 sources.
+let winrtDisplayInfo = false
+let winrtDisplayInfoFailed = false
+function getWinRTDisplayInfo() {
+    if (winrtDisplayInfo || winrtDisplayInfoFailed) return winrtDisplayInfo;
+    try {
+        winrtDisplayInfo = require("tt-windows-utils").DisplayInfo
+    } catch (e) {
+        console.log("Couldn't load WinRT display info module", e)
+        winrtDisplayInfoFailed = true
+    }
+    return winrtDisplayInfo
+}
+
+getMonitorsWinRT = async () => {
+    const foundMonitors = {}
+    try {
+        const displayInfo = getWinRTDisplayInfo()
+        if (!displayInfo?.getDisplayMonitors) return foundMonitors;
+
+        const displays = displayInfo.getDisplayMonitors()
+        for (const display of displays) {
+            if (!display?.deviceInterfaceId) continue;
+
+            const path = display.deviceInterfaceId
+            const keyEnd = path.indexOf("#{")
+            const hwid = (keyEnd >= 0 ? path.substring(0, keyEnd) : path).split("#")
+            if (hwid.length < 3) continue;
+            hwid[2] = hwid[2].split("_")[0]
+
+            const winrtInfo = {
+                key: hwid[2],
+                isInternal: (display.connectionKind === "internal"),
+                connectionKind: display.connectionKind,
+                physicalConnector: display.physicalConnector
+            }
+            if (display.nativeWidth > 0 && display.nativeHeight > 0) {
+                winrtInfo.nativeResolution = {
+                    width: display.nativeWidth,
+                    height: display.nativeHeight
+                }
+            }
+            if (display.physicalDiagonal > 0) {
+                winrtInfo.physicalSize = {
+                    width: display.physicalWidth,
+                    height: display.physicalHeight,
+                    diagonal: display.physicalDiagonal
+                }
+            }
+            if (display.name) {
+                winrtInfo.winrtName = display.name
+            }
+
+            foundMonitors[hwid[2]] = winrtInfo
+        }
+    } catch (e) {
+        console.log("getMonitorsWinRT: Failed to get display info.", e)
+    }
+    return foundMonitors
 }
 
 let win32Failed = false

--- a/src/components/SettingsWindow.jsx
+++ b/src/components/SettingsWindow.jsx
@@ -1230,6 +1230,7 @@ export default class SettingsWindow extends PureComponent {
                                         <SettingsChild title={"WMIC"} input={this.renderToggle("disableWMIC", true, "right", true)} />
                                         <SettingsChild title={"WMI-Bridge"} input={this.renderToggle("disableWMI", true, "right", true)} />
                                         <SettingsChild title={"Win32-DisplayConfig"} input={this.renderToggle("disableWin32", true, "right", true)} />
+                                        <SettingsChild title={"WinRT-DisplayMonitor"} input={this.renderToggle("disableWinRT", true, "right", true)} />
                                     </SettingsOption>
 
                                    <SettingsOption title={T.t("SETTINGS_GENERAL_LEGACY_DDC_TITLE")} description={T.t("SETTINGS_GENERAL_LEGACY_DDC_DESC")} input={

--- a/src/electron.js
+++ b/src/electron.js
@@ -625,6 +625,7 @@ const defaultSettings = {
   disableWMIC: false,
   disableWMI: false,
   disableWin32: false,
+  disableWinRT: false,
   disableHDR: false,
   autoDisabledWMI: false,
   useWin32Event: true,

--- a/src/modules/tt-windows-utils/binding.gyp
+++ b/src/modules/tt-windows-utils/binding.gyp
@@ -69,6 +69,23 @@
         "<!@(node -p \"require('node-addon-api').include\")"
       ],
       'defines': [ 'NAPI_CPP_EXCEPTIONS' ],
+    },
+    {
+      "target_name": "windows_display_info",
+      "cflags!": [ ],
+      "cflags_cc!": [ ],
+      "conditions": [
+        ["OS=='win'", {
+          "sources": [ "windows_display_info.cc" ]
+        }],
+      ],
+      'msvs_settings': {
+        'VCCLCompilerTool': { "ExceptionHandling": 1 }
+      },
+      "include_dirs": [
+        "<!@(node -p \"require('node-addon-api').include\")"
+      ],
+      'defines': [ 'NAPI_CPP_EXCEPTIONS' ],
     }
   ]
 }

--- a/src/modules/tt-windows-utils/index.js
+++ b/src/modules/tt-windows-utils/index.js
@@ -4,7 +4,17 @@ const PowerEvents = require("bindings")("windows_power_events");
 const MediaStatus = require("bindings")("windows_media_status");
 const AppStartup = require("bindings")("windows_app_startup");
 const WindowMaterial = require("bindings")("windows_window_material");
-const DisplayInfo = require("bindings")("windows_display_info");
+
+// DisplayMonitor is an optional WinRT enrichment source. Load it only when
+// requested so a missing or unloadable binding cannot prevent the app itself
+// from starting.
+let DisplayInfo = null;
+function getDisplayInfo() {
+    if (!DisplayInfo) {
+        DisplayInfo = require("bindings")("windows_display_info");
+    }
+    return DisplayInfo;
+}
 
 module.exports = {
     WindowUtils: {
@@ -25,8 +35,11 @@ module.exports = {
         getPlaybackStatus: MediaStatus.getPlaybackStatus,
         getPlaybackInfo: MediaStatus.getPlaybackInfo
     },
-    DisplayInfo: {
-        getDisplayMonitors: DisplayInfo.getDisplayMonitors
+    get DisplayInfo() {
+        const displayInfo = getDisplayInfo();
+        return {
+            getDisplayMonitors: displayInfo.getDisplayMonitors
+        };
     },
     AppStartup: {
         enable: AppStartup.enable,

--- a/src/modules/tt-windows-utils/index.js
+++ b/src/modules/tt-windows-utils/index.js
@@ -4,6 +4,7 @@ const PowerEvents = require("bindings")("windows_power_events");
 const MediaStatus = require("bindings")("windows_media_status");
 const AppStartup = require("bindings")("windows_app_startup");
 const WindowMaterial = require("bindings")("windows_window_material");
+const DisplayInfo = require("bindings")("windows_display_info");
 
 module.exports = {
     WindowUtils: {
@@ -23,6 +24,9 @@ module.exports = {
     MediaStatus: {
         getPlaybackStatus: MediaStatus.getPlaybackStatus,
         getPlaybackInfo: MediaStatus.getPlaybackInfo
+    },
+    DisplayInfo: {
+        getDisplayMonitors: DisplayInfo.getDisplayMonitors
     },
     AppStartup: {
         enable: AppStartup.enable,

--- a/src/modules/tt-windows-utils/windows_display_info.cc
+++ b/src/modules/tt-windows-utils/windows_display_info.cc
@@ -1,0 +1,155 @@
+#include <napi.h>
+#pragma comment(lib, "windowsapp")
+#include <winrt/Windows.Devices.Display.h>
+#include <winrt/Windows.Devices.Enumeration.h>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Graphics.h>
+
+#include <cmath>
+#include <string>
+
+using namespace winrt;
+using namespace Windows::Devices::Display;
+using namespace Windows::Devices::Enumeration;
+
+std::string connectionKindToString(DisplayMonitorConnectionKind kind) {
+  switch (kind) {
+  case DisplayMonitorConnectionKind::Internal:
+    return "internal";
+  case DisplayMonitorConnectionKind::Wired:
+    return "wired";
+  case DisplayMonitorConnectionKind::Wireless:
+    return "wireless";
+  case DisplayMonitorConnectionKind::Virtual:
+    return "virtual";
+  }
+  return "unknown";
+}
+
+std::string physicalConnectorToString(DisplayMonitorPhysicalConnectorKind kind) {
+  switch (kind) {
+  case DisplayMonitorPhysicalConnectorKind::HD15:
+    return "vga";
+  case DisplayMonitorPhysicalConnectorKind::AnalogTV:
+    return "analogTV";
+  case DisplayMonitorPhysicalConnectorKind::Dvi:
+    return "dvi";
+  case DisplayMonitorPhysicalConnectorKind::Hdmi:
+    return "hdmi";
+  case DisplayMonitorPhysicalConnectorKind::Lvds:
+    return "lvds";
+  case DisplayMonitorPhysicalConnectorKind::Sdi:
+    return "sdi";
+  case DisplayMonitorPhysicalConnectorKind::DisplayPort:
+    return "displayPort";
+  case DisplayMonitorPhysicalConnectorKind::Unknown:
+    break;
+  }
+  return "unknown";
+}
+
+// Enumerates monitors via Windows.Devices.Display.DisplayMonitor.
+// Provides definitive internal/external classification, physical size,
+// and native resolution that the Win32 enumeration APIs don't expose.
+Napi::Array getDisplayMonitors(const Napi::CallbackInfo &info) {
+  Napi::Array out = Napi::Array::New(info.Env());
+  int index = 0;
+
+  // The monitor thread doesn't initialize COM on its own. WinRT needs an
+  // apartment; use MTA to match the other native modules in this process.
+  static bool apartmentAttempted = false;
+  if (!apartmentAttempted) {
+    apartmentAttempted = true;
+    try {
+      winrt::init_apartment(winrt::apartment_type::multi_threaded);
+    } catch (...) {
+      // Already initialized by the host. Existing apartment is usable.
+    }
+  }
+
+  try {
+    auto devices_async =
+        DeviceInformation::FindAllAsync(DisplayMonitor::GetDeviceSelector());
+    if (devices_async.wait_for(std::chrono::milliseconds{2000}) !=
+        Windows::Foundation::AsyncStatus::Completed) {
+      return out;
+    }
+    auto devices = devices_async.get();
+
+    for (auto const &device : devices) {
+      try {
+        auto monitor_async = DisplayMonitor::FromInterfaceIdAsync(device.Id());
+        if (monitor_async.wait_for(std::chrono::milliseconds{1000}) !=
+            Windows::Foundation::AsyncStatus::Completed) {
+          continue;
+        }
+        DisplayMonitor monitor = monitor_async.get();
+        if (monitor == nullptr)
+          continue;
+
+        Napi::Object monitorObj = Napi::Object::New(info.Env());
+
+        // e.g. "\\?\DISPLAY#ABC1234#5&...&UID4352#{GUID}" - same shape as
+        // the device paths used by the other enumeration sources.
+        monitorObj.Set("deviceInterfaceId",
+                       Napi::String::New(info.Env(),
+                                         winrt::to_string(device.Id())));
+        monitorObj.Set(
+            "deviceInstanceId",
+            Napi::String::New(info.Env(),
+                              winrt::to_string(monitor.DeviceId())));
+
+        monitorObj.Set("name",
+                       Napi::String::New(
+                           info.Env(),
+                           winrt::to_string(monitor.DisplayName())));
+
+        monitorObj.Set("connectionKind",
+                       Napi::String::New(
+                           info.Env(),
+                           connectionKindToString(monitor.ConnectionKind())));
+        monitorObj.Set(
+            "physicalConnector",
+            Napi::String::New(
+                info.Env(),
+                physicalConnectorToString(monitor.PhysicalConnector())));
+
+        auto resolution = monitor.NativeResolutionInRawPixels();
+        monitorObj.Set("nativeWidth",
+                       Napi::Number::New(info.Env(), resolution.Width));
+        monitorObj.Set("nativeHeight",
+                       Napi::Number::New(info.Env(), resolution.Height));
+
+        auto physicalSize = monitor.PhysicalSizeInInches();
+        if (physicalSize != nullptr) {
+          float width = physicalSize.Value().Width;
+          float height = physicalSize.Value().Height;
+          monitorObj.Set("physicalWidth", Napi::Number::New(info.Env(), width));
+          monitorObj.Set("physicalHeight",
+                         Napi::Number::New(info.Env(), height));
+          monitorObj.Set(
+              "physicalDiagonal",
+              Napi::Number::New(
+                  info.Env(),
+                  std::sqrt((double)width * width + (double)height * height)));
+        }
+
+        out.Set(index++, monitorObj);
+      } catch (...) {
+        // Skip monitors that fail to resolve; keep enumerating the rest.
+      }
+    }
+  } catch (...) {
+  }
+
+  return out;
+}
+
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+  exports.Set(Napi::String::New(env, "getDisplayMonitors"),
+              Napi::Function::New(env, getDisplayMonitors));
+  return exports;
+}
+
+NODE_API_MODULE(NODE_GYP_MODULE_NAME, Init);


### PR DESCRIPTION
## What

Adds `Windows.Devices.Display.DisplayMonitor` (WinRT, Windows 10 1803+) as an additional enumeration source and merges its data into the monitor list. It provides display facts the current Win32/WMI sources can't:

- **`isInternal` / `connectionKind`** — definitive internal-vs-external classification straight from the display pipeline. Today "internal" is effectively inferred from *which monitor answers WMI brightness queries*; this gives an explicit signal that features like `hideClosedLid` can build on.
- **`physicalConnector`** (HDMI/DP/LVDS/…), **physical size in inches** (incl. diagonal), and **native resolution** — useful for display identification UI.
- **Display name** — used only as a fallback when neither WMI nor Win32 provided one.

## Implementation

- New `windows_display_info` target in `tt-windows-utils`, following the same C++/WinRT pattern as the existing `windows_media_status` target (`#pragma comment(lib, "windowsapp")`, bounded `wait_for()` on async ops — 2s for enumeration, 1s per monitor). MTA apartment is initialized on first use since the monitor thread doesn't set one up.
- `Monitors.js` merges results keyed by the same `\?\DISPLAY#<model>#<instance>` device path the other sources use, so fields land on existing monitor entries. Everything is additive; load or enumeration failures degrade silently.

## Verification

- Compiles cleanly alongside the existing targets (node-gyp rebuild, MSVC x64).
- Live-tested: correctly reports the internal panel as `connectionKind: "internal"`, 2880×1800 native, 15.9″ diagonal, with a device interface ID that exactly matches the device paths from the DDC/CI and HDR sources.
- JS syntax checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)