### PR TITLE
Add fast-first monitor details refresh

### DIFF
--- a/src/Monitors.js
+++ b/src/Monitors.js
@@ -267,20 +267,25 @@ function featureSnapshotKey(monitor) {
     return Array.isArray(monitor?.hwid) ? monitor.hwid.join("#") : false
 }
 
+function saveFeatureSnapshot(monitor, acceptInvalidatedSnapshots = false) {
+    if (!monitor?.ddcciSupported || monitor.featuresPending || monitor.featuresRefreshing) return false
+    const monitorId = monitor.hwid?.[1]
+    if (invalidatedFeatureSnapshotMonitorIds.has(monitorId) && !acceptInvalidatedSnapshots) return false
+    const key = featureSnapshotKey(monitor)
+    const snapshot = deepCopy({
+        features: monitor.features || {},
+        vcpCodes: monitor.vcpCodes || {}
+    })
+    if (!key || !snapshot) return false
+
+    monitorFeatureSnapshots[key] = snapshot
+    if (acceptInvalidatedSnapshots) invalidatedFeatureSnapshotMonitorIds.delete(monitorId)
+    return true
+}
+
 function saveFeatureSnapshots(source = monitors, acceptInvalidatedSnapshots = false) {
     for (const monitor of Object.values(source || {})) {
-        if (!monitor?.ddcciSupported || monitor.featuresPending || monitor.featuresRefreshing) continue
-        const monitorId = monitor.hwid?.[1]
-        if (invalidatedFeatureSnapshotMonitorIds.has(monitorId) && !acceptInvalidatedSnapshots) continue
-        const key = featureSnapshotKey(monitor)
-        const snapshot = deepCopy({
-            features: monitor.features || {},
-            vcpCodes: monitor.vcpCodes || {}
-        })
-        if (key && snapshot) {
-            monitorFeatureSnapshots[key] = snapshot
-            if (acceptInvalidatedSnapshots) invalidatedFeatureSnapshotMonitorIds.delete(monitorId)
-        }
+        saveFeatureSnapshot(monitor, acceptInvalidatedSnapshots)
     }
 }
 
@@ -1509,9 +1514,10 @@ async function setVCP(monitor, code, value) {
         }
         
         const hwid = monitor.split("#")
-        if(monitors[hwid[2]]?.features?.[vcpString]) {
-            monitors[hwid[2]].features[vcpString][0] = parseInt(value)
-            saveFeatureSnapshots(monitors)
+        const updatedMonitor = monitors[hwid[2]]
+        if(updatedMonitor?.features?.[vcpString]) {
+            updatedMonitor.features[vcpString][0] = parseInt(value)
+            saveFeatureSnapshot(updatedMonitor)
         }
         return result
     } catch (e) {

--- a/src/Monitors.js
+++ b/src/Monitors.js
@@ -297,8 +297,13 @@ function applyFeatureSnapshots(foundMonitors) {
 
         // Current Fast readings take precedence (especially brightness), while
         // the last verified feature set keeps controls available during refresh.
-        monitor.features = Object.assign({}, snapshot.features || {}, monitor.features || {})
-        monitor.vcpCodes = Object.assign({}, snapshot.vcpCodes || {}, monitor.vcpCodes || {})
+        // Keep the session cache isolated from the live model. A VCP update
+        // must not silently mutate a snapshot that was intentionally frozen.
+        const snapshotFeatures = deepCopy(snapshot.features || {})
+        const snapshotVcpCodes = deepCopy(snapshot.vcpCodes || {})
+        if (!snapshotFeatures || !snapshotVcpCodes) continue
+        monitor.features = Object.assign({}, snapshotFeatures, monitor.features || {})
+        monitor.vcpCodes = Object.assign({}, snapshotVcpCodes, monitor.vcpCodes || {})
         monitor.featuresPending = false
         monitor.featuresRefreshing = true
     }

--- a/src/Monitors.js
+++ b/src/Monitors.js
@@ -22,27 +22,41 @@ function deepCopy(obj) {
     }
 }
 
-process.on('message', async (data) => {
+async function handleMonitorMessage(data) {
     try {
         if (data.type === "refreshMonitors") {
             if(data.clearCache) {
                 vcpCache = {}
                 monitorReports = {}
                 monitorReportsRaw = {}
+                monitorFeatureSnapshots = {}
+                invalidatedFeatureSnapshotMonitorIds.clear()
             }
-            refreshMonitors(data.fullRefresh, data.ddcciType).then((results) => {
-                lastRefresh = deepCopy(results)
-                process.send({
-                    type: 'refreshMonitors',
-                    monitors: results
-                })
+            const results = await refreshMonitors(data.fullRefresh, data.ddcciType)
+            lastRefresh = deepCopy(results)
+            process.send({
+                type: 'refreshMonitors',
+                monitors: results,
+                generation: data.generation,
+                canEnrichCapabilities: !!(data.fullRefresh && shouldEnrichCapabilities())
+            })
+        } else if (data.type === "enrichMonitorCapabilities") {
+            const results = await enrichMonitorCapabilities()
+            if (results) lastRefresh = deepCopy(results)
+            process.send({
+                type: 'monitorsEnriched',
+                monitors: (results || false),
+                generation: data.generation,
+                failed: !results
             })
         } else if (data.type === "brightness") {
             setBrightness(data.brightness, data.id)
         }  else if (data.type === "sdr") {
             setSDRBrightness(data.brightness, data.id)
         } else if (data.type === "settings") {
+            const changedMonitors = changedFeatureMonitorIds(settings, data.settings || {})
             settings = data.settings
+            invalidateFeatureSnapshots(changedMonitors)
 
             // Overrides
             if (settings?.disableAppleStudio) appleStudioUnavailable = true;
@@ -51,7 +65,12 @@ process.on('message', async (data) => {
             if (settings?.disableWin32) win32Failed = true;
 
         } else if (data.type === "ddcBrightnessVCPs") {
+            const changedMonitors = changedFeatureMonitorIds(
+                { userDDCBrightnessVCPs: ddcBrightnessVCPs },
+                { userDDCBrightnessVCPs: data.ddcBrightnessVCPs || {} }
+            )
             ddcBrightnessVCPs = data.ddcBrightnessVCPs
+            invalidateFeatureSnapshots(changedMonitors)
             // Update brightnessType for all monitors when user changes VCP settings
             if (monitors) {
                 for (const hwid2 in monitors) {
@@ -83,6 +102,8 @@ process.on('message', async (data) => {
             vcpCache = {}
             monitorReports = {}
             monitorReportsRaw = {}
+            monitorFeatureSnapshots = {}
+            invalidatedFeatureSnapshotMonitorIds.clear()
             ddcci._clearDisplayCache()
         } else if (data.type === "wmi-bridge-ok") {
             canUseWmiBridge = data.value
@@ -116,7 +137,7 @@ process.on('message', async (data) => {
     } catch (e) {
         console.log(e)
     }
-})
+}
 
 let isDev = (process.argv.indexOf("--isdev=true") >= 0)
 let skipTest = (process.argv.indexOf("--skiptest=true") >= 0)
@@ -233,12 +254,78 @@ let monitorsAppleStudio = {}
 let monitorsWin32 = {}
 let monitorReports = {}
 let monitorReportsRaw = {}
+let monitorFeatureSnapshots = {}
+let invalidatedFeatureSnapshotMonitorIds = new Set()
 
 let settings = { order: [] }
 let localization = {}
 let canUseWmiBridge = false
 
 let ddcBrightnessVCPs = {}
+
+function featureSnapshotKey(monitor) {
+    return Array.isArray(monitor?.hwid) ? monitor.hwid.join("#") : false
+}
+
+function saveFeatureSnapshots(source = monitors, acceptInvalidatedSnapshots = false) {
+    for (const monitor of Object.values(source || {})) {
+        if (!monitor?.ddcciSupported || monitor.featuresPending || monitor.featuresRefreshing) continue
+        const monitorId = monitor.hwid?.[1]
+        if (invalidatedFeatureSnapshotMonitorIds.has(monitorId) && !acceptInvalidatedSnapshots) continue
+        const key = featureSnapshotKey(monitor)
+        const snapshot = deepCopy({
+            features: monitor.features || {},
+            vcpCodes: monitor.vcpCodes || {}
+        })
+        if (key && snapshot) {
+            monitorFeatureSnapshots[key] = snapshot
+            if (acceptInvalidatedSnapshots) invalidatedFeatureSnapshotMonitorIds.delete(monitorId)
+        }
+    }
+}
+
+function applyFeatureSnapshots(foundMonitors) {
+    for (const monitor of Object.values(foundMonitors || {})) {
+        if (!monitor?.ddcciSupported || monitor.type !== "ddcci" || !monitor.featuresPending) continue
+        const snapshot = monitorFeatureSnapshots[featureSnapshotKey(monitor)]
+        if (!snapshot) continue
+
+        // Current Fast readings take precedence (especially brightness), while
+        // the last verified feature set keeps controls available during refresh.
+        monitor.features = Object.assign({}, snapshot.features || {}, monitor.features || {})
+        monitor.vcpCodes = Object.assign({}, snapshot.vcpCodes || {}, monitor.vcpCodes || {})
+        monitor.featuresPending = false
+        monitor.featuresRefreshing = true
+    }
+}
+
+function changedFeatureMonitorIds(previous = {}, next = {}) {
+    const ids = new Set()
+    const settingGroups = [
+        "monitorFeatures",
+        "monitorFeaturesSettings",
+        "userDDCBrightnessVCPs"
+    ]
+    for (const group of settingGroups) {
+        for (const id of new Set([
+            ...Object.keys(previous[group] || {}),
+            ...Object.keys(next[group] || {})
+        ])) {
+            if (JSON.stringify(previous[group]?.[id]) !== JSON.stringify(next[group]?.[id])) {
+                ids.add(id)
+            }
+        }
+    }
+    return ids
+}
+
+function invalidateFeatureSnapshots(monitorIds) {
+    if (!monitorIds?.size) return
+    for (const id of monitorIds) invalidatedFeatureSnapshotMonitorIds.add(id)
+    for (const key of Object.keys(monitorFeatureSnapshots)) {
+        if (monitorIds.has(key.split("#")[1])) delete monitorFeatureSnapshots[key]
+    }
+}
 
 let busyLevel = 0
 refreshMonitors = async (fullRefresh = false, ddcciType = "default", alwaysSendUpdate = false) => {
@@ -250,7 +337,13 @@ refreshMonitors = async (fullRefresh = false, ddcciType = "default", alwaysSendU
         busyLevel = (fullRefresh ? 2 : 1)
 
         if (!monitors || fullRefresh) {
-            const foundMonitors = await getAllMonitors(determineDDCCIMethod())
+            if (fullRefresh) saveFeatureSnapshots(monitors)
+            const useCapabilityEnrichment = shouldEnrichCapabilities()
+            const foundMonitors = await getAllMonitors(
+                (useCapabilityEnrichment ? "fast" : determineDDCCIMethod()),
+                useCapabilityEnrichment
+            )
+            if (useCapabilityEnrichment) applyFeatureSnapshots(foundMonitors)
             monitors = foundMonitors
         } else {
             let startTime = process.hrtime()
@@ -259,7 +352,11 @@ refreshMonitors = async (fullRefresh = false, ddcciType = "default", alwaysSendU
             try {
                 if (settings?.getDDCBrightnessUpdates) {
                     if(!getDDCCI()) {
-                        ddcci._refresh(determineDDCCIMethod(), true, !settings.disableHighLevel)
+                        ddcci._refresh(
+                            (shouldEnrichCapabilities() ? "fast" : determineDDCCIMethod()),
+                            true,
+                            !settings.disableHighLevel
+                        )
                     }
                     for (const hwid2 in monitors) {
                         if (monitors[hwid2].type === "ddcci" && monitors[hwid2].brightnessType) {
@@ -349,8 +446,55 @@ refreshMonitors = async (fullRefresh = false, ddcciType = "default", alwaysSendU
     return monitors
 }
 
+// Accurate and Auto scans publish a usable Fast result before requesting
+// capabilities strings, which are the least reliable DDC/CI operation.
+async function enrichMonitorCapabilities() {
+    if (busyLevel > 0 || !monitors || !shouldEnrichCapabilities()) {
+        console.log("Skipping capabilities enrichment.")
+        return false
+    }
 
-getAllMonitors = async (ddcciMethod = "default") => {
+    busyLevel = 2
+    try {
+        getDDCCI()
+        const monitorsToEnrich = Array.isArray(lastDDCCIList) ? [...lastDDCCIList] : []
+
+        for (const monitor of monitorsToEnrich) {
+            const id = monitor?.deviceKey
+            if (!id || monitorReports[id] || unstableDDC[id]) continue
+
+            try {
+                const reportRaw = withDDCSentinel("capabilities", id, () =>
+                    ddcci.getCapabilitiesRaw(id)
+                )
+                if (reportRaw) {
+                    monitorReportsRaw[id] = reportRaw
+                    const report = ddcci._parseCapabilitiesString(reportRaw)
+                    if (report && Object.keys(report).length > 0) {
+                        monitorReports[id] = report
+                    }
+                }
+            } catch (e) {
+                // One optional report must not invalidate the Fast result.
+                console.log("Couldn't get capabilities report for monitor " + id)
+            }
+        }
+
+        // The native cache now owns the capabilities strings. Rebuild the
+        // normal feature set without requesting another string from hardware.
+        monitors = await getAllMonitors("fast", false)
+        saveFeatureSnapshots(monitors, true)
+        return monitors
+    } catch (e) {
+        console.log("Couldn't enrich monitor capabilities", e)
+        return false
+    } finally {
+        busyLevel = 0
+    }
+}
+
+
+getAllMonitors = async (ddcciMethod = "default", coreOnly = false) => {
     const foundMonitors = {}
     let startTime = process.hrtime.bigint()
     let fullStartTime = process.hrtime.bigint()
@@ -420,7 +564,7 @@ getAllMonitors = async (ddcciMethod = "default") => {
     // DDC/CI Brightness + Features
     try {
         startTime = process.hrtime.bigint()
-        const featuresList = await getFeaturesDDC(ddcciMethod, false)
+        const featuresList = await getFeaturesDDC(ddcciMethod, coreOnly)
 
         for (const hwid2 in featuresList) {
             const monitor = featuresList[hwid2]
@@ -442,6 +586,7 @@ getAllMonitors = async (ddcciMethod = "default") => {
                 highLevelSupported,
                 features: features,
                 vcpCodes: vcpCodes,
+                featuresPending: !!coreOnly,
                 type: ((ddcciSupported || highLevelSupported?.brightness) && brightnessType ? "ddcci" : "none"),
                 min: 0,
                 max: 100,
@@ -584,6 +729,15 @@ function determineDDCCIMethod() {
         ddcciMethod = "fast"
     }
     return ddcciMethod
+}
+
+function shouldEnrichCapabilities() {
+    const savedMethod = settings?.preferredDDCCIMethod
+    if (savedMethod === "accurate") return true
+    // Auto keeps its crash-recovery behavior: don't retry a capabilities read
+    // after a worker died while probing DDC/CI.
+    if (savedMethod === "auto") return !unstableDDC.downgraded
+    return false
 }
 
 let appleStudioUnavailable = false
@@ -890,7 +1044,7 @@ getMonitorsWin32 = () => {
     })
 }
 
-getFeaturesDDC = (ddcciMethod = "accurate") => {
+getFeaturesDDC = (ddcciMethod = "accurate", coreOnly = false) => {
     const monitorFeatures = {}
     return new Promise(async (resolve, reject) => {
         try {
@@ -958,7 +1112,7 @@ getFeaturesDDC = (ddcciMethod = "accurate") => {
                         monitorReports[id] = monitor.capabilities
                     }
 
-                    if(monitor.ddcciSupported && !shouldAbortFeatureScan()) {
+                    if(monitor.ddcciSupported && !coreOnly && !shouldAbortFeatureScan()) {
                         await wait(10)
                         features = await checkMonitorFeatures(id, false, ddcciMethod, shouldAbortFeatureScan)
                     }
@@ -1357,6 +1511,7 @@ async function setVCP(monitor, code, value) {
         const hwid = monitor.split("#")
         if(monitors[hwid[2]]?.features?.[vcpString]) {
             monitors[hwid[2]].features[vcpString][0] = parseInt(value)
+            saveFeatureSnapshots(monitors)
         }
         return result
     } catch (e) {
@@ -1719,16 +1874,21 @@ testDDCCIMethods = async () => {
 }
 
 
+// Auto now uses the same Fast-first/enrichment flow as Accurate, so probing
+// Accurate before the worker is ready would defeat the startup improvement.
+// Keep the legacy test helper available for diagnostics, but don't run it as
+// part of the worker bootstrap.
 let isFastFine = true
-testDDCCIMethods().then(result => {
-    isFastFine = result
-    if(!skipTest) {
-        process.send({
-            type: 'ddcciModeTestResult',
-            value: isFastFine
-        })
-    }
-    process.send({
-        type: 'ready'
-    })
+process.send({
+    type: 'ready'
+})
+
+// Node does not await asynchronous EventEmitter listeners. Keep DDC/CI and
+// cache mutations in one worker-side queue so a late IPC message cannot
+// interleave with a refresh or a capabilities read.
+let monitorMessageQueue = Promise.resolve()
+process.on('message', data => {
+    monitorMessageQueue = monitorMessageQueue
+        .then(() => handleMonitorMessage(data))
+        .catch(e => console.log(e))
 })

--- a/src/components/DDCCISliders.jsx
+++ b/src/components/DDCCISliders.jsx
@@ -109,6 +109,8 @@ export default function DDCCISliders(props) {
 
     return (
         <>
+            {monitor.featuresPending ? (<div className="feature-row feature-pending">Detecting display features…</div>) : null}
+            {monitor.featuresRefreshing ? (<div className="feature-row feature-pending">Refreshing display features…</div>) : null}
             {extraHTML}
         </>
     )

--- a/src/components/MonitorFeatures.jsx
+++ b/src/components/MonitorFeatures.jsx
@@ -12,6 +12,14 @@ export default function MonitorFeatures(props) {
 
     let extraHTML = []
 
+    if (monitor.featuresPending) {
+        return (<div className="description">Detecting display features…</div>)
+    }
+
+    if (monitor.featuresRefreshing) {
+        extraHTML.push(<div className="description" key="features-refreshing">Refreshing display features…</div>)
+    }
+
     const inputsData = {
         1: "VGA-1",
         2: "VGA-2",

--- a/src/components/MonitorFeatures.jsx
+++ b/src/components/MonitorFeatures.jsx
@@ -13,11 +13,11 @@ export default function MonitorFeatures(props) {
     let extraHTML = []
 
     if (monitor.featuresPending) {
-        return (<div className="description">Detecting display features…</div>)
+        extraHTML.push(<div className="description" style={{padding: "8px 0"}}>Detecting display features…</div>)
     }
 
     if (monitor.featuresRefreshing) {
-        extraHTML.push(<div className="description" key="features-refreshing">Refreshing display features…</div>)
+        extraHTML.push(<div className="description" style={{padding: "8px 0"}} key="features-refreshing">Refreshing display features…</div>)
     }
 
     const inputsData = {

--- a/src/electron.js
+++ b/src/electron.js
@@ -264,7 +264,18 @@ let monitorsThreadReady = false
 let monitorsThreadStarting = false
 let monitorsThreadFailed = false
 let monitorsThreadFailedResetTimer = false
+let monitorThreadRecoveryPromise = false
+let monitorInventoryRecoveryTimer = false
+let isAppQuitting = false
 let ddcSafetyRetryPromise = false
+
+app.on('before-quit', () => {
+  isAppQuitting = true
+  if (monitorInventoryRecoveryTimer) {
+    clearTimeout(monitorInventoryRecoveryTimer)
+    monitorInventoryRecoveryTimer = false
+  }
+})
 
 function getDDCSafetyStatus() {
   try {
@@ -325,7 +336,8 @@ function startMonitorThread({ allowWhileWindowsIdle = false } = {}) {
   console.log("Starting monitor thread")
   const skipTest = (settings.preferredDDCCIMethod == "auto" ? false : true)
   monitorsThreadReal = fork(path.join(__dirname, 'Monitors.js'), ["--isdev=" + isDev, "--apppath=" + app.getAppPath(), "--skiptest=" + skipTest, "--datapath=" + app.getPath("userData")], { silent: false })
-  monitorsThreadReal.on("message", (data) => {
+  const monitorThread = monitorsThreadReal
+  monitorThread.on("message", (data) => {
     if (data?.type) {
       if (data.type === "ready") {
         monitorsThreadReady = true
@@ -361,33 +373,19 @@ function startMonitorThread({ allowWhileWindowsIdle = false } = {}) {
       monitorsEventEmitter.emit(data.type, data)
     }
   })
-  monitorsThreadReal.on("error", err => {
-    console.error(err)
-
-    // Suppress duplicate dialogs from the same failure episode, but never
-    // suppress recovery. The flag is reset when a replacement reaches ready.
-    if(!monitorsThreadFailed) {
-      monitorsThreadFailed = true
-      const options = {
-        title: 'Monitors thread failed',
-        message: 'The monitors thread failed with the following message:',
-        detail: err.message || err.toString(),
-      };
-      require('electron').dialog.showMessageBox(null, options, (response, checkboxChecked) => { });
-    }
-
-    if(monitorsThreadFailedResetTimer) {
-      clearTimeout(monitorsThreadFailedResetTimer)
-      monitorsThreadFailedResetTimer = false
-    }
-
-    stopMonitorThread().then(async () => {
-      // Pace restarts so a repeatedly-failing thread doesn't stop/start in
-      // a tight loop.
-      await Utils.wait(1000)
-      startMonitorThread({ allowWhileWindowsIdle: true })
-    }).catch(stopError => {
-      console.error("Couldn't restart monitor thread.", stopError)
+  monitorThread.on("error", error => {
+    recoverMonitorThread(monitorThread, error).then(recovered => {
+      if (recovered && !activeCapabilitiesEnrichmentPromise) {
+        scheduleMonitorInventoryRecovery()
+      }
+    })
+  })
+  monitorThread.once("exit", (code, signal) => {
+    const error = new Error(`Monitor thread exited (code: ${code}, signal: ${signal}).`)
+    recoverMonitorThread(monitorThread, error).then(recovered => {
+      if (recovered && !activeCapabilitiesEnrichmentPromise) {
+        scheduleMonitorInventoryRecovery()
+      }
     })
   })
   return monitorsThreadReal
@@ -431,6 +429,56 @@ function waitForMonitorThreadReady(thread = monitorsThreadReal) {
 
 let monitorsThreadStopPromise = false
 let monitorsThreadStopTarget = false
+function scheduleMonitorInventoryRecovery(generation = monitorRefreshGeneration) {
+  if (monitorInventoryRecoveryTimer) return
+  monitorInventoryRecoveryTimer = setTimeout(async () => {
+    monitorInventoryRecoveryTimer = false
+    if (isAppQuitting || !monitorsThreadReady || activeCapabilitiesEnrichmentPromise || queuedRefreshPromise) return
+    if (generation !== monitorRefreshGeneration) return
+    await refreshMonitors(true, true, true, hasEnabledLinkedFeatures(), true)
+  }, 0)
+}
+
+function recoverMonitorThread(thread, error) {
+  // An explicit stop (wake recovery, validation retry, timeout recovery) has
+  // its own replacement/refresh path and must not race this fallback.
+  if (isAppQuitting || !thread || monitorsThreadStopTarget === thread) return Promise.resolve(false)
+  if (monitorThreadRecoveryPromise) return monitorThreadRecoveryPromise
+
+  console.error(error)
+  if (!monitorsThreadFailed) {
+    monitorsThreadFailed = true
+    require('electron').dialog.showMessageBox(null, {
+      title: 'Monitors thread failed',
+      message: 'The monitors thread failed with the following message:',
+      detail: error?.message || error?.toString() || 'Unknown error',
+    }, () => { })
+  }
+
+  if (monitorsThreadFailedResetTimer) {
+    clearTimeout(monitorsThreadFailedResetTimer)
+    monitorsThreadFailedResetTimer = false
+  }
+
+  monitorThreadRecoveryPromise = (async () => {
+    if (monitorsThreadReal === thread) await stopMonitorThread()
+    // Pace restarts so a repeatedly-failing worker cannot loop tightly.
+    await Utils.wait(1000)
+    if (isAppQuitting) return false
+    const replacement = startMonitorThread({ allowWhileWindowsIdle: true }) || monitorsThreadReal
+    if (!replacement) throw new Error("Monitor thread could not be restarted.")
+    await waitForMonitorThreadReady(replacement)
+    return true
+  })().catch(recoveryError => {
+    console.error("Couldn't restart monitor thread.", recoveryError)
+    return false
+  }).finally(() => {
+    monitorThreadRecoveryPromise = false
+  })
+
+  return monitorThreadRecoveryPromise
+}
+
 function stopMonitorThread() {
   console.log("Killing monitor thread")
   monitorsThreadReady = false
@@ -2123,6 +2171,7 @@ enrichMonitorCapabilitiesJob = async (generation) => {
         cleanup()
         const error = new Error("Monitor worker stopped during capabilities enrichment.")
         error.code = "MONITOR_WORKER_STOPPED"
+        error.worker = worker
         reject(error)
       }
       const timeout = setTimeout(() => {
@@ -2359,8 +2408,16 @@ function queueCapabilitiesEnrichment(generation) {
   }).catch(async error => {
     console.log("Couldn't enrich monitor capabilities", error)
     if (error?.code === "MONITOR_WORKER_STOPPED") {
+      // Keep a queued full refresh behind the replacement worker's ready
+      // signal, even when that refresh has already superseded this generation.
+      const recovered = await recoverMonitorThread(error.worker, error)
       if (generation === monitorRefreshGeneration) {
         clearFeaturesPendingAfterEnrichmentFailure()
+        if (recovered && !queuedRefreshPromise) {
+          // Wait for this promise's finally block to release the exclusive
+          // slot, then rebuild the replacement worker's monitor inventory.
+          scheduleMonitorInventoryRecovery(generation)
+        }
       }
       return
     }

--- a/src/electron.js
+++ b/src/electron.js
@@ -501,7 +501,8 @@ async function getVCP(monitor, code) {
       // Write VCP values to monitor object
       if(data?.value?.[0] != undefined) {
         try {
-          monitors[hwid?.split("#")[2]].features[vcpStr(vcpParsed)] = data.value?.[0]
+          const feature = monitors[hwid?.split("#")[2]]?.features?.[vcpStr(vcpParsed)]
+          if (Array.isArray(feature)) feature[0] = data.value[0]
         } catch(e) {
           console.log(e)
         }

--- a/src/electron.js
+++ b/src/electron.js
@@ -142,8 +142,87 @@ function vcpStr(code) {
 // Monitors thread
 // Handles WMI + DDC/CI activity
 
+const monitorCommandsThatMutateWorkerState = new Set([
+  "brightness", "sdr", "vcp", "getVCP", "flushvcp", "settings",
+  "ddcBrightnessVCPs", "localization", "wmi-bridge-ok"
+])
+const monitorCommandsRequiredBeforeRefresh = new Set([
+  "flushvcp", "settings", "ddcBrightnessVCPs", "localization", "wmi-bridge-ok"
+])
+let queuedMonitorCommands = []
+let flushingMonitorCommands = false
+
+function monitorWorkerHasExclusiveWork() {
+  return !!(isRefreshing || activeCapabilitiesEnrichmentPromise || queuedRefreshPromise)
+}
+
+async function waitForMonitorWorkerIdle() {
+  while (monitorWorkerHasExclusiveWork()) {
+    if (activeCapabilitiesEnrichmentPromise) {
+      await activeCapabilitiesEnrichmentPromise
+    } else if (queuedRefreshPromise) {
+      await queuedRefreshPromise
+    } else {
+      await Utils.wait(50)
+    }
+  }
+}
+
+async function flushQueuedMonitorCommands(beforeRefresh = false) {
+  const exclusiveWorkInProgress = !!(isRefreshing || activeCapabilitiesEnrichmentPromise)
+  if (flushingMonitorCommands) {
+    while (flushingMonitorCommands) await Utils.wait(10)
+    return flushQueuedMonitorCommands(beforeRefresh)
+  }
+  if (exclusiveWorkInProgress || (!beforeRefresh && queuedRefreshPromise) || !queuedMonitorCommands.length) return
+  flushingMonitorCommands = true
+  const commands = []
+  const remainingCommands = []
+  for (const command of queuedMonitorCommands) {
+    if (!beforeRefresh || monitorCommandsRequiredBeforeRefresh.has(command.data.type)) {
+      commands.push(command)
+    } else {
+      remainingCommands.push(command)
+    }
+  }
+  queuedMonitorCommands = remainingCommands
+
+  try {
+    for (const command of commands) {
+      if (!monitorCommandsRequiredBeforeRefresh.has(command.data.type)
+        && command.generation !== monitorRefreshGeneration
+        && !queuedCommandTargetsCurrentMonitor(command.data)) {
+        command.resolve()
+        continue
+      }
+      await monitorsThread.sendNow(command.data)
+      command.resolve()
+    }
+  } catch (error) {
+    for (const command of commands) command.reject(error)
+  } finally {
+    flushingMonitorCommands = false
+    if (queuedMonitorCommands.length && !beforeRefresh) flushQueuedMonitorCommands()
+  }
+}
+
+function queuedCommandTargetsCurrentMonitor(data) {
+  if (data.type === "brightness" || data.type === "sdr") {
+    if (!data.id) return true
+    return Object.values(monitors || {}).some(monitor =>
+      monitor?.id === data.id || monitor?.id?.indexOf(data.id) >= 0
+    )
+  }
+  if (data.type === "vcp" || data.type === "getVCP") {
+    return Object.values(monitors || {}).some(monitor =>
+      monitor?.hwid?.join("#") === data.monitor
+    )
+  }
+  return false
+}
+
 let monitorsThread = {
-  send: async function (data) {
+  sendNow: async function (data) {
     try {
       if (!(monitorsThreadReal?.connected && monitorsThreadReal?.exitCode === null)) {
         startMonitorThread()
@@ -153,13 +232,19 @@ let monitorsThread = {
       }
       if(!monitorsThreadReady) throw("Thread not ready!");
       if(!(monitorsThreadReal?.connected && monitorsThreadReal?.exitCode === null)) throw("Thread not available!");
-      if((data.type == "vcp" || data.type == "brightness" || data.type == "getVCP") && isRefreshing) while(isRefreshing) {
-        await Utils.wait(50)
-      }
       monitorsThreadReal.send(data)
     } catch (e) {
       console.log("Couldn't communicate with Monitor thread.", e)
+      return false
     }
+  },
+  send: function (data) {
+    if (monitorCommandsThatMutateWorkerState.has(data.type) && monitorWorkerHasExclusiveWork()) {
+      return new Promise((resolve, reject) => {
+        queuedMonitorCommands.push({ data, resolve, reject, generation: monitorRefreshGeneration })
+      })
+    }
+    return this.sendNow(data)
   },
   once: function (message, callback) {
     try {
@@ -400,7 +485,10 @@ function stopMonitorThread() {
   return stopPromise
 }
 
-function getVCP(monitor, code) {
+async function getVCP(monitor, code) {
+  // Offset/cycle hotkeys need a real value; don't let a synchronous
+  // capabilities request turn their three-second timeout into -1.
+  await waitForMonitorWorkerIdle()
   return new Promise((resolve, reject) => {
     if (!monitor || !code) resolve(-1);
     const vcpParsed = parseInt(`0x${parseInt(code).toString(16).toUpperCase()}`)
@@ -1974,15 +2062,20 @@ const setIsRefreshing = newValue => {
 }
 
 
-refreshMonitorsJob = async (fullRefresh = false) => {
+refreshMonitorsJob = async (fullRefresh = false, generation = 0) => {
   return await new Promise((resolve, reject) => {
     try {
-      monitorsThread.send({
-        type: "refreshMonitors",
-        fullRefresh
-      })
-
-      let timeout = setTimeout(() => {
+      const cleanup = () => {
+        clearTimeout(timeout)
+        monitorsEventEmitter.removeListener("refreshMonitors", listener)
+      }
+      const listener = data => {
+        if (data?.generation !== generation) return
+        cleanup()
+        resolve(data)
+      }
+      const timeout = setTimeout(() => {
+        cleanup()
         reject("Monitor thread timed out.")
 
         // Attempt to fix common issue with wmi-bridge by relying only on Win32
@@ -1992,24 +2085,298 @@ refreshMonitorsJob = async (fullRefresh = false) => {
           settings.disableWMI = true
         }
       }, 60000)
+      monitorsEventEmitter.on("refreshMonitors", listener)
 
-      function listen(resolve) {
-        monitorsThread.once("refreshMonitors", data => {
-          clearTimeout(timeout)
-          resolve(data.monitors)
-        })
-      }
-      listen(resolve)
+      monitorsThread.send({
+        type: "refreshMonitors",
+        fullRefresh,
+        generation
+      })
     } catch (e) {
       reject("Monitor thread failed to send.")
     }
   })
 }
 
+enrichMonitorCapabilitiesJob = async (generation) => {
+  return await new Promise((resolve, reject) => {
+    let cleanup = () => { }
+    try {
+      const worker = monitorsThreadReal
+      if (!(worker?.connected && worker?.exitCode === null)) {
+        throw new Error("Monitor worker is not available for capabilities enrichment.")
+      }
+      cleanup = () => {
+        clearTimeout(timeout)
+        monitorsEventEmitter.removeListener("monitorsEnriched", listener)
+        worker.removeListener("exit", workerStopped)
+        worker.removeListener("error", workerStopped)
+      }
+      const listener = data => {
+        if (data?.generation !== generation) return
+        cleanup()
+        resolve(data)
+      }
+      const workerStopped = () => {
+        cleanup()
+        const error = new Error("Monitor worker stopped during capabilities enrichment.")
+        error.code = "MONITOR_WORKER_STOPPED"
+        reject(error)
+      }
+      const timeout = setTimeout(() => {
+        cleanup()
+        reject(new Error("Monitor capabilities enrichment timed out."))
+      }, 60000)
+      monitorsEventEmitter.on("monitorsEnriched", listener)
+      worker.once("exit", workerStopped)
+      worker.once("error", workerStopped)
+
+      worker.send({
+        type: "enrichMonitorCapabilities",
+        generation
+      })
+    } catch (e) {
+      cleanup()
+      reject(new Error("Monitor thread failed to start capabilities enrichment."))
+    }
+  })
+}
+
 let lastRefreshMonitors = 0
 let lastCompletedRefresh = 0
+let monitorRefreshGeneration = 0
+let activeCapabilitiesEnrichment = 0
+let activeCapabilitiesEnrichmentPromise = false
+let queuedRefreshRequest = false
+let queuedRefreshPromise = false
+const deferredFeatureUpdates = new Map()
+const deferredLinkedFeatureUpdates = new Map()
 
-async function refreshMonitors(fullRefresh = false, bypassRateLimit = false, bypassWindowsIdle = false) {
+async function waitForActiveMonitorWork() {
+  while (isRefreshing || activeCapabilitiesEnrichmentPromise) {
+    if (activeCapabilitiesEnrichmentPromise) {
+      await activeCapabilitiesEnrichmentPromise
+    } else {
+      await Utils.wait(50)
+    }
+  }
+}
+
+function queueRefreshAfterEnrichment(fullRefresh, bypassRateLimit, bypassWindowsIdle, waitForFeatureEnrichment) {
+  const generation = ++monitorRefreshGeneration
+  // Preserve explicit user feature changes across a superseding full refresh.
+  // They are replayed only if the matching monitor is still present later.
+  for (const update of deferredFeatureUpdates.values()) update.generation = generation
+  for (const update of deferredLinkedFeatureUpdates.values()) update.generation = generation
+
+  if (!queuedRefreshRequest) {
+    queuedRefreshRequest = {
+      fullRefresh,
+      bypassRateLimit,
+      bypassWindowsIdle,
+      waitForFeatureEnrichment,
+      generation
+    }
+    queuedRefreshPromise = (async () => {
+      await waitForActiveMonitorWork()
+      await flushQueuedMonitorCommands(true)
+      const request = queuedRefreshRequest
+      return refreshMonitors(
+        request.fullRefresh,
+        request.bypassRateLimit,
+        request.bypassWindowsIdle,
+        request.waitForFeatureEnrichment,
+        true,
+        request.generation
+      )
+    })().finally(() => {
+      queuedRefreshRequest = false
+      queuedRefreshPromise = false
+      flushQueuedMonitorCommands()
+    })
+  } else {
+    queuedRefreshRequest.fullRefresh = queuedRefreshRequest.fullRefresh || fullRefresh
+    queuedRefreshRequest.bypassRateLimit = queuedRefreshRequest.bypassRateLimit || bypassRateLimit
+    queuedRefreshRequest.bypassWindowsIdle = queuedRefreshRequest.bypassWindowsIdle || bypassWindowsIdle
+    queuedRefreshRequest.waitForFeatureEnrichment = queuedRefreshRequest.waitForFeatureEnrichment || waitForFeatureEnrichment
+    queuedRefreshRequest.generation = generation
+  }
+
+  return queuedRefreshPromise
+}
+
+function hasEnabledLinkedFeatures() {
+  try {
+    return Object.entries(settings.monitorFeaturesSettings || {}).some(([monitorId, features]) =>
+      Object.entries(features || {}).some(([vcp, featureSettings]) =>
+        featureSettings?.linked && settings.monitorFeatures?.[monitorId]?.[vcp]
+      )
+    )
+  } catch (e) {
+    return false
+  }
+}
+
+function deferFeatureUpdate(monitor, level, useCap, vcpValue, clearTransition = true) {
+  if (!monitor?.id) return false
+  deferredFeatureUpdates.set(`${monitor.id}:${vcpValue}`, {
+    generation: monitorRefreshGeneration,
+    monitorId: monitor.id,
+    level,
+    useCap,
+    vcpValue,
+    clearTransition
+  })
+  return true
+}
+
+function deferLinkedFeatureUpdate(monitor, level, useCap) {
+  if (!monitor?.id) return false
+  deferredLinkedFeatureUpdates.set(monitor.id, {
+    generation: monitorRefreshGeneration,
+    monitorId: monitor.id,
+    level,
+    useCap
+  })
+  return true
+}
+
+function flushDeferredFeatureUpdates() {
+  if (Object.values(monitors).some(monitor => monitor?.featuresPending || monitor?.featuresRefreshing)) return
+
+  const featureUpdates = [...deferredFeatureUpdates.values()]
+  const linkedUpdates = [...deferredLinkedFeatureUpdates.values()]
+  deferredFeatureUpdates.clear()
+  deferredLinkedFeatureUpdates.clear()
+
+  for (const update of featureUpdates) {
+    if (update.generation !== monitorRefreshGeneration) continue
+    const monitor = Object.values(monitors).find(item => item?.id === update.monitorId)
+    if (monitor) {
+      updateBrightness(update.monitorId, update.level, update.useCap, update.vcpValue, update.clearTransition)
+    }
+  }
+
+  for (const update of linkedUpdates) {
+    if (update.generation !== monitorRefreshGeneration) continue
+    const monitor = Object.values(monitors).find(item => item?.id === update.monitorId)
+    if (monitor) {
+      applyLinkedFeatures(monitor, update.level, update.useCap)
+    }
+  }
+}
+
+function clearFeaturesPendingAfterEnrichmentFailure() {
+  const oldMonitors = JSON.stringify(monitors)
+  for (const monitor of Object.values(monitors)) {
+    if (monitor?.featuresPending) monitor.featuresPending = false
+    if (monitor?.featuresRefreshing) monitor.featuresRefreshing = false
+  }
+  flushDeferredFeatureUpdates()
+  if (JSON.stringify(monitors) !== oldMonitors) {
+    sendToAllWindows('monitors-updated', monitors)
+  }
+}
+
+function commitRefreshedMonitors(newMonitors, oldMonitors = {}) {
+  applyOrder(newMonitors)
+  applyRemaps(newMonitors)
+  applyHotkeys(newMonitors)
+
+  // Normalize values
+  for (let id in newMonitors) {
+    const monitor = newMonitors[id]
+    monitor.brightness = normalizeBrightness(monitor.brightness, true, monitor.min, monitor.max, monitor.calibration)
+
+    // Replace DDC/CI brightness with SDR
+    if(settings.sdrAsMainSliderDisplays?.[monitor.key] && monitor.hdr === "active") {
+      monitor.brightness = monitor.sdrLevel
+    }
+
+    // Other DDC/CI normalizations
+    const featuresSettings = settings.monitorFeaturesSettings?.[monitor.hwid[1]]
+    if(featuresSettings) {
+      for(const vcp in monitor.features) {
+        if(featuresSettings[vcp] && featuresSettings[vcp].min >= 0 && featuresSettings[vcp].max <= 100) {
+          monitor.features[vcp][0] = normalizeBrightness(monitor.features[vcp][0], true, featuresSettings[vcp].min, featuresSettings[vcp].max)
+        }
+      }
+    }
+  }
+
+  monitors = newMonitors
+  lastCompletedRefresh = Date.now()
+  lightSensor.setMonitors(monitors)
+  flushDeferredFeatureUpdates()
+
+  if (JSON.stringify(newMonitors) !== JSON.stringify(oldMonitors)) {
+    setTrayPercent()
+    sendToAllWindows('monitors-updated', monitors)
+  } else {
+    console.log("===--- NO CHANGE ---===")
+  }
+}
+
+async function recoverFromCapabilitiesTimeout(generation) {
+  console.log("Capabilities enrichment timed out. Restarting monitor worker while keeping the Fast results.")
+  try {
+    if (activeCapabilitiesEnrichment === generation) {
+      activeCapabilitiesEnrichment = 0
+      activeCapabilitiesEnrichmentPromise = false
+    }
+    await stopMonitorThread()
+    const thread = startMonitorThread({ allowWhileWindowsIdle: true })
+    if (!thread) return
+    await waitForMonitorThreadReady(thread)
+    if (generation === monitorRefreshGeneration && !queuedRefreshPromise) {
+      return await refreshMonitors(true, true, true, hasEnabledLinkedFeatures(), true)
+    }
+  } catch (e) {
+    console.log("Couldn't recover monitor worker after capabilities timeout", e)
+  }
+}
+
+function queueCapabilitiesEnrichment(generation) {
+  if (activeCapabilitiesEnrichmentPromise) return activeCapabilitiesEnrichmentPromise
+  activeCapabilitiesEnrichment = generation
+
+  let enrichmentPromise
+  enrichmentPromise = enrichMonitorCapabilitiesJob(generation).then(data => {
+    if (data?.generation !== generation || generation !== monitorRefreshGeneration) {
+      return
+    }
+
+    if (!data.monitors) {
+      console.log("Monitor capabilities enrichment completed without feature data.")
+      clearFeaturesPendingAfterEnrichmentFailure()
+      return
+    }
+
+    const oldMonitors = Object.assign({}, monitors)
+    commitRefreshedMonitors(data.monitors, oldMonitors)
+  }).catch(async error => {
+    console.log("Couldn't enrich monitor capabilities", error)
+    if (error?.code === "MONITOR_WORKER_STOPPED") {
+      if (generation === monitorRefreshGeneration) {
+        clearFeaturesPendingAfterEnrichmentFailure()
+      }
+      return
+    }
+    await recoverFromCapabilitiesTimeout(generation)
+  }).finally(() => {
+    // A timeout recovery can start a new enrichment for the same refresh
+    // generation. Only the promise that owns this slot may clear it.
+    if (activeCapabilitiesEnrichmentPromise === enrichmentPromise) {
+      activeCapabilitiesEnrichment = 0
+      activeCapabilitiesEnrichmentPromise = false
+    }
+    flushQueuedMonitorCommands()
+  })
+  activeCapabilitiesEnrichmentPromise = enrichmentPromise
+  return enrichmentPromise
+}
+
+async function refreshMonitors(fullRefresh = false, bypassRateLimit = false, bypassWindowsIdle = false, waitForFeatureEnrichment = false, skipEnrichmentQueue = false, reservedGeneration = false) {
 
   if (isWindowsUserIdle && !bypassWindowsIdle) {
     console.log("Displays are off, no updates.")
@@ -2021,9 +2388,22 @@ async function refreshMonitors(fullRefresh = false, bypassRateLimit = false, byp
     return monitors
   }
 
+  if (!skipEnrichmentQueue && (activeCapabilitiesEnrichmentPromise || queuedRefreshPromise)) {
+    console.log("Waiting for capabilities enrichment before refreshing monitors.")
+    if (!fullRefresh) {
+      await (activeCapabilitiesEnrichmentPromise || queuedRefreshPromise)
+      return monitors
+    }
+    return queueRefreshAfterEnrichment(fullRefresh, bypassRateLimit, bypassWindowsIdle, waitForFeatureEnrichment)
+  }
+
   // Don't do 2+ refreshes at once
   if (isRefreshing) {
-    console.log(`Already refreshing. Aborting.`)
+    console.log(`Already refreshing.`)
+    if (fullRefresh) {
+      console.log("Queueing the full refresh after the current worker operation.")
+      return queueRefreshAfterEnrichment(fullRefresh, bypassRateLimit, bypassWindowsIdle, waitForFeatureEnrichment)
+    }
     return monitors;
   }
 
@@ -2049,61 +2429,31 @@ async function refreshMonitors(fullRefresh = false, bypassRateLimit = false, byp
   // Save old monitors for comparison
   let oldMonitors = Object.assign({}, monitors)
   let newMonitors
+  let canEnrichCapabilities = false
+  const generation = (reservedGeneration || ++monitorRefreshGeneration)
 
   let failed = false
   try {
-    newMonitors = await refreshMonitorsJob(fullRefresh)
+    const result = await refreshMonitorsJob(fullRefresh, generation)
+    newMonitors = result?.monitors
+    canEnrichCapabilities = !!result?.canEnrichCapabilities
     if (!newMonitors) {
       failed = true;
       throw "No monitors recieved!";
     }
-    lastEagerUpdate = Date.now()
+    if (generation !== monitorRefreshGeneration) {
+      console.log("Discarding a superseded monitor refresh.")
+      failed = true
+    } else {
+      lastEagerUpdate = Date.now()
+    }
   } catch (e) {
     failed = true
     console.log('Couldn\'t refresh monitors', e)
   }
 
   if (!failed) {
-    applyOrder(newMonitors)
-    applyRemaps(newMonitors)
-    applyHotkeys(newMonitors)
-
-    // Normalize values
-    for (let id in newMonitors) {
-      const monitor = newMonitors[id]
-      // Brightness
-      monitor.brightness = normalizeBrightness(monitor.brightness, true, monitor.min, monitor.max, monitor.calibration)
-
-
-      // Replace DDC/CI brightness with SDR
-      if(settings.sdrAsMainSliderDisplays?.[monitor.key] && monitor.hdr === "active") {
-        monitor.brightness = monitor.sdrLevel
-      }
-
-      // Other DDC/CI normalizations
-      const featuresSettings = settings.monitorFeaturesSettings?.[monitor.hwid[1]]
-      if(featuresSettings) {
-        // For each feature, check for matching normalization data
-        for(const vcp in monitor.features) {
-          if(featuresSettings[vcp] && featuresSettings[vcp].min >= 0 && featuresSettings[vcp].max <= 100) {
-            monitor.features[vcp][0] = normalizeBrightness(monitor.features[vcp][0], true, featuresSettings[vcp].min, featuresSettings[vcp].max)
-          }
-        }
-      }
-
-    }
-
-    monitors = newMonitors;
-    lastCompletedRefresh = Date.now()
-    lightSensor.setMonitors(monitors)
-
-    // Only send update if something changed
-    if (JSON.stringify(newMonitors) !== JSON.stringify(oldMonitors)) {
-      setTrayPercent()
-      sendToAllWindows('monitors-updated', monitors)
-    } else {
-      console.log("===--- NO CHANGE ---===")
-    }
+    commitRefreshedMonitors(newMonitors, oldMonitors)
   }
 
   if (shouldShowPanel) {
@@ -2113,6 +2463,11 @@ async function refreshMonitors(fullRefresh = false, bypassRateLimit = false, byp
 
   console.log("\x1b[34m---------------------------------------------- \x1b[0m")
   setIsRefreshing(false)
+  if (!failed && canEnrichCapabilities) {
+    const enrichmentPromise = queueCapabilitiesEnrichment(generation)
+    if (waitForFeatureEnrichment) await enrichmentPromise
+  }
+  flushQueuedMonitorCommands()
   return monitors;
 }
 
@@ -2175,6 +2530,33 @@ function updateBrightnessThrottle(id, level, useCap = true, sendUpdate = true, v
 
 let ignoreBrightnessEvent = false
 let ignoreBrightnessEventTimeout = false
+
+function hasEnabledLinkedFeaturesForMonitor(monitor) {
+  const monitorId = monitor?.hwid?.[1]
+  if (!monitorId) return false
+  return Object.entries(settings.monitorFeaturesSettings?.[monitorId] || {}).some(([vcp, featureSettings]) =>
+    featureSettings?.linked && settings.monitorFeatures?.[monitorId]?.[vcp]
+  )
+}
+
+function applyLinkedFeatures(monitor, newLevel, useCap = true) {
+  const featuresSettings = settings.monitorFeaturesSettings?.[monitor.hwid?.[1]]
+  if (!featuresSettings) return
+
+  for(const vcp in monitor.features || {}) {
+    if(featuresSettings[vcp]?.linked && settings.monitorFeatures?.[monitor.hwid[1]]?.[vcp]) {
+      const maxBrightness = (featuresSettings[vcp].maxVisual ?? 100)
+      let processedLevel = newLevel
+      if(processedLevel > maxBrightness) {
+        processedLevel = maxBrightness
+      }
+
+      const capped = parseInt(normalizeBrightness(processedLevel, true, 0, maxBrightness))
+      updateBrightnessThrottle(monitor.id, capped, useCap, false, vcp)
+    }
+  }
+}
+
 function updateBrightness(index, newLevel, useCap = true, vcpValue = "brightness", clearTransition = true) {
   if(isWindowsUserIdle) return false; // Skip if displays are off
   try {
@@ -2212,6 +2594,14 @@ function updateBrightness(index, newLevel, useCap = true, vcpValue = "brightness
     if(vcp == "brightness" && monitor.hdr === "active" && settings.sdrAsMainSliderDisplays?.[monitor.key]) {
       vcp = "sdr"
       useCap = false
+    }
+
+    // Feature VCPs need the enriched monitor map. A Fast-only result can be
+    // used for brightness, but queue feature work until it is safe to run.
+    if ((monitor.featuresPending || monitor.featuresRefreshing)
+      && ((vcp !== "brightness" && vcp !== "sdr") || monitor.type === "none")) {
+      deferFeatureUpdate(monitor, newLevel, useCap, vcpValue, clearTransition)
+      return true
     }
 
     if (clearTransition && currentTransition) {
@@ -2252,23 +2642,11 @@ function updateBrightness(index, newLevel, useCap = true, vcpValue = "brightness
           monitor.brightness = monitor.sdrLevel
         }
 
-        // Apply linked DDC/CI features
-        const featuresSettings = settings.monitorFeaturesSettings?.[monitor.hwid[1]]
-        if(featuresSettings) {
-          // For each feature, check for linked value
-          for(const vcp in monitor.features) {
-            if(featuresSettings[vcp]?.linked && settings.monitorFeatures?.[monitor.hwid[1]]?.[vcp]) {
-
-              const maxBrightness = (featuresSettings[vcp].maxVisual ?? 100)
-              let processedLevel = newLevel
-              if(processedLevel > maxBrightness) {
-                processedLevel = maxBrightness
-              }
-
-              const capped = parseInt(normalizeBrightness(processedLevel, true, 0, maxBrightness))
-              updateBrightnessThrottle(index, capped, useCap, false, vcp)
-            }
-          }
+        // Apply linked DDC/CI features now, or replay them after enrichment.
+        if (monitor.featuresPending && hasEnabledLinkedFeaturesForMonitor(monitor)) {
+          deferLinkedFeatureUpdate(monitor, newLevel, useCap)
+        } else {
+          applyLinkedFeatures(monitor, newLevel, useCap)
         }
       } else {
         const vcpString = `0x${parseInt(vcp).toString(16).toUpperCase()}`
@@ -2509,6 +2887,7 @@ function sleepDisplays(mode = "ps", delayMS = 333) {
 
 async function turnOffDisplayDDC(hwid, toggle = false) {
   try {
+    await waitForMonitorWorkerIdle()
     const offVal = parseInt(settings.ddcPowerOffValue)
     if (toggle) {
       const currentValue = await getVCP(hwid, 0xD6)
@@ -3442,7 +3821,7 @@ app.on("ready", async () => {
     })
 
     isRefreshing = false
-    await refreshMonitors(true, true)
+    await refreshMonitors(true, true, false, hasEnabledLinkedFeatures())
 
     if (settings.brightnessAtStartup) setKnownBrightness();
     if (settings.checkTimeAtStartup) {
@@ -4159,7 +4538,7 @@ function handleMonitorChange(t, e, d) {
     if(settings.recreateTray) recreateTray();
 
     // Reset all known displays
-    await refreshMonitors(true)
+    await refreshMonitors(true, false, false, hasEnabledLinkedFeatures())
 
     // During startup grace period, use current monitor brightness instead of saved profile
     // This prevents overwriting brightness that was manually set before shutdown
@@ -4251,7 +4630,7 @@ powerMonitor.on("resume", async () => {
     const refreshWaitDeadline = Date.now() + 30000
     while((isRefreshing || pausedMonitorUpdates) && Date.now() < refreshWaitDeadline) await Utils.wait(50)
     const refreshRequested = Date.now()
-    await refreshMonitors(true, true, true)
+    await refreshMonitors(true, true, true, hasEnabledLinkedFeatures())
 
     if (!settings.disableAutoRefresh) {
       if (!settings.disableAutoApply && !hasRecentlyInteracted) setKnownBrightness();
@@ -4300,7 +4679,7 @@ function handleMetricsChange(type) {
     if(handleChangeTimeout2) return false;
 
     // Do a quick check to ensure handles are all good
-    await refreshMonitors(true)
+    await refreshMonitors(true, false, false, hasEnabledLinkedFeatures())
 
     // During startup grace period, use current monitor brightness instead of saved profile
     // This prevents overwriting brightness that was manually set before shutdown

--- a/src/electron.js
+++ b/src/electron.js
@@ -2366,10 +2366,12 @@ function queueCapabilitiesEnrichment(generation) {
     await recoverFromCapabilitiesTimeout(generation)
   }).finally(() => {
     // A timeout recovery can start a new enrichment for the same refresh
-    // generation. Only the promise that owns this slot may clear it.
+    // generation. Only the promise that owns this slot may clear it or end
+    // the panel's loading state.
     if (activeCapabilitiesEnrichmentPromise === enrichmentPromise) {
       activeCapabilitiesEnrichment = 0
       activeCapabilitiesEnrichmentPromise = false
+      setIsRefreshing(false)
     }
     flushQueuedMonitorCommands()
   })
@@ -2463,10 +2465,11 @@ async function refreshMonitors(fullRefresh = false, bypassRateLimit = false, byp
   }
 
   console.log("\x1b[34m---------------------------------------------- \x1b[0m")
-  setIsRefreshing(false)
   if (!failed && canEnrichCapabilities) {
     const enrichmentPromise = queueCapabilitiesEnrichment(generation)
     if (waitForFeatureEnrichment) await enrichmentPromise
+  } else {
+    setIsRefreshing(false)
   }
   flushQueuedMonitorCommands()
   return monitors;

--- a/src/electron.js
+++ b/src/electron.js
@@ -2137,12 +2137,20 @@ refreshMonitorsJob = async (fullRefresh = false, generation = 0) => {
       }, 60000)
       monitorsEventEmitter.on("refreshMonitors", listener)
 
-      monitorsThread.send({
+      Promise.resolve(monitorsThread.send({
         type: "refreshMonitors",
         fullRefresh,
         generation
+      })).then(sent => {
+        if (sent !== false) return
+        cleanup()
+        reject("Monitor thread failed to send.")
+      }).catch(() => {
+        cleanup()
+        reject("Monitor thread failed to send.")
       })
     } catch (e) {
+      cleanup()
       reject("Monitor thread failed to send.")
     }
   })

--- a/src/electron.js
+++ b/src/electron.js
@@ -195,8 +195,8 @@ async function flushQueuedMonitorCommands(beforeRefresh = false) {
         command.resolve()
         continue
       }
-      await monitorsThread.sendNow(command.data)
-      command.resolve()
+      const sent = await monitorsThread.sendNow(command.data)
+      command.resolve(sent !== false)
     }
   } catch (error) {
     for (const command of commands) command.reject(error)
@@ -233,6 +233,7 @@ let monitorsThread = {
       if(!monitorsThreadReady) throw("Thread not ready!");
       if(!(monitorsThreadReal?.connected && monitorsThreadReal?.exitCode === null)) throw("Thread not available!");
       monitorsThreadReal.send(data)
+      return true
     } catch (e) {
       console.log("Couldn't communicate with Monitor thread.", e)
       return false

--- a/src/modules/node-ddcci/ddcci.cc
+++ b/src/modules/node-ddcci/ddcci.cc
@@ -69,6 +69,36 @@ std::map<std::string, HANDLE> handles;
 std::map<std::string, PhysicalMonitor> physicalMonitorHandles;
 std::map<std::string, std::string> capabilities;
 
+PhysicalMonitor*
+findPhysicalMonitor(const std::string& monitorName)
+{
+    for (auto& entry : physicalMonitorHandles) {
+        PhysicalMonitor& monitor = entry.second;
+        if (entry.first == monitorName || monitor.name == monitorName
+            || monitor.fullName == monitorName
+            || monitor.physicalName == monitorName
+            || monitor.deviceKey == monitorName
+            || monitor.deviceID == monitorName) {
+            return &monitor;
+        }
+    }
+
+    return nullptr;
+}
+
+void
+applyCapabilitiesResult(PhysicalMonitor* monitor,
+                        const std::string& result)
+{
+    if (monitor == nullptr || result.empty()) return;
+
+    monitor->result = result;
+    monitor->ddcciSupported = true;
+    if (!monitor->deviceKey.empty()) {
+        capabilities[monitor->deviceKey] = result;
+    }
+}
+
 int logLevel = 0;
 
 // `handles` owns every physical-monitor handle. `physicalMonitorHandles`
@@ -1061,15 +1091,24 @@ getNAPICapabilitiesString(const Napi::CallbackInfo& info)
     }
 
     std::string monitorName = info[0].As<Napi::String>().Utf8Value();
+    PhysicalMonitor* physicalMonitor = findPhysicalMonitor(monitorName);
+    const std::string cacheKey = (physicalMonitor != nullptr
+      && !physicalMonitor->deviceKey.empty())
+      ? physicalMonitor->deviceKey
+      : monitorName;
 
     // Check if it's already saved in memory first.
-    auto found = capabilities.find(monitorName);
+    auto found = capabilities.find(cacheKey);
     if (found != capabilities.end()) {
+        applyCapabilitiesResult(physicalMonitor, found->second);
         return Napi::String::New(env, found->second);
     }
 
     // Find requested monitor.
-    auto it = handles.find(monitorName);
+    auto it = handles.find(cacheKey);
+    if (it == handles.end()) {
+        it = handles.find(monitorName);
+    }
     if (it == handles.end()) {
         throw Napi::Error::New(env, "Monitor not found");
     }
@@ -1079,6 +1118,14 @@ getNAPICapabilitiesString(const Napi::CallbackInfo& info)
     if(returnString == "") {
         throw Napi::Error::New(
           env, "Monitor not responding."); // Does not respond to DDC/CI
+    }
+
+    // A capabilities request can be performed after a fast discovery pass.
+    // Persist it in both native caches so later refreshes and input discovery
+    // observe the enriched state without another hardware request.
+    applyCapabilitiesResult(physicalMonitor, returnString);
+    if (physicalMonitor == nullptr) {
+        capabilities[cacheKey] = returnString;
     }
 
     return Napi::String::New(env, returnString);


### PR DESCRIPTION
## Summary

- Publish a Fast monitor result before capability-string enrichment for Accurate and Auto detection.
- Move capability enrichment into the main refresh coordinator with worker serialization, generation checks, timeout recovery, and safe command deferral.
- Reuse session-only enriched feature snapshots during later full refreshes, with targeted invalidation for feature-setting changes.

## Why

Capability-string reads are the slowest and least reliable DDC/CI operation. Previously they could delay the initial usable monitor state and temporarily remove feature controls on full refreshes.

## User impact

Brightness remains available from the Fast result. Existing feature controls stay visible as refreshing when a verified session snapshot is available; new or invalidated monitors continue through the detection state.

## Validation

- `node --check src/Monitors.js`
- `node --check src/electron.js`
- `git diff --check`
- `npm.cmd run parcel-build`

Hardware smoke testing with slow/unreliable capability reads and sleep/resume is still recommended.
