### PR TITLE
Add comprehensive session-based file logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
       "src/monitor-rules.json",
       "src/localization/*",
       "src/Utils.js",
+      "src/Logger.js",
       "src/Monitors.js",
       "src/wmi-bridge-test.js",
       "src/vcp-codes.js",

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -1,0 +1,170 @@
+// Session-based file logger for the main process.
+// All console output (main, forked children, renderers via IPC) funnels here into
+// one log file per session, rotated so at most MAX_KEEP session files are kept.
+// Note: native stdout from addons loaded in the main process (e.g. win32-displayconfig)
+// bypasses process.stdout.write and can't be captured here. Native output from the
+// Monitors child (e.g. node-ddcci's std::cout) IS captured, via attachChild's pipes.
+const fs = require('fs')
+const path = require('path')
+const util = require('util')
+const readline = require('readline')
+
+const MAX_KEEP = 3
+const MAX_BYTES = 50 * 1024 * 1024
+
+// Real stdout/stderr and console, captured before any console patching
+const realStdoutWrite = process.stdout.write.bind(process.stdout)
+const realStderrWrite = process.stderr.write.bind(process.stderr)
+const origConsole = {
+  log: console.log,
+  info: console.info,
+  debug: console.debug,
+  warn: console.warn,
+  error: console.error
+}
+
+let stream = null
+let sessionPath = null
+let bytesWritten = 0
+let capped = false
+let mirrorLogEnabled = true
+const preInitBuffer = []
+
+const stripAnsi = (s) => s.replace(/\x1b\[[0-9;]*m/g, "")
+
+function timestamp() {
+  const d = new Date()
+  const p = (n, l = 2) => String(n).padStart(l, "0")
+  return `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}.${p(d.getMilliseconds(), 3)}`
+}
+
+function serialize(args) {
+  return args.map(a =>
+    typeof a === "string" ? a :
+    a instanceof Error ? (a.stack || a.message) :
+    util.inspect(a, { depth: 4, maxArrayLength: 50, breakLength: Infinity })
+  ).join(" ")
+}
+
+function formatLine(tag, level, args) {
+  const lvl = (level === "warn" || level === "error") ? ":" + level.toUpperCase().slice(0, 3) : ""
+  return `[${timestamp()}] [${tag}${lvl}] ${stripAnsi(serialize(args))}\r\n`
+}
+
+function appendLine(line) {
+  if (capped) return;
+  if (!stream) {
+    preInitBuffer.push(line)
+    return;
+  }
+  bytesWritten += Buffer.byteLength(line)
+  if (bytesWritten > MAX_BYTES) {
+    capped = true
+    stream.write(`[${timestamp()}] [LOGGER] Log size cap reached (${MAX_BYTES} bytes); file logging stopped for this session.\r\n`)
+    return;
+  }
+  stream.write(line)
+}
+
+function writeLog(tag, level, ...args) {
+  appendLine(formatLine(tag, level, args))
+}
+
+// Synchronous write for fatal errors, where the process may die before the stream flushes
+function writeLogSync(tag, level, ...args) {
+  const line = formatLine(tag, level, args)
+  if (capped || !sessionPath) return;
+  try {
+    fs.appendFileSync(sessionPath, line)
+  } catch (e) { }
+}
+
+function initMainLogger({ dir, isDev = false } = {}) {
+  const logDir = path.join(dir, "logs")
+  const suffix = isDev ? "-dev" : ""
+  try {
+    fs.mkdirSync(logDir, { recursive: true })
+
+    // Dev and non-dev sessions rotate as separate pools (like settings-dev.json)
+    const pattern = isDev ? /^session-.*-dev\.log$/ : /^session-(?!.*-dev\.log).*\.log$/
+    const existing = fs.readdirSync(logDir).filter(f => pattern.test(f)).sort()
+    for (const old of existing.slice(0, Math.max(0, existing.length - (MAX_KEEP - 1)))) {
+      try { fs.unlinkSync(path.join(logDir, old)) } catch (e) { }
+    }
+
+    // Zero-padded so name sort == chronological sort; PID guards same-second collisions
+    const d = new Date()
+    const p = (n, l = 2) => String(n).padStart(l, "0")
+    const stamp = `${d.getFullYear()}${p(d.getMonth() + 1)}${p(d.getDate())}-${p(d.getHours())}${p(d.getMinutes())}${p(d.getSeconds())}-${process.pid}`
+    sessionPath = path.join(logDir, `session-${stamp}${suffix}.log`)
+    stream = fs.createWriteStream(sessionPath, { flags: "a" })
+    stream.on("error", () => { stream = null; capped = true })
+  } catch (e) {
+    // File logging unavailable (permissions, disk); console keeps working
+    realStderrWrite(`Logger init failed: ${e}\r\n`)
+    capped = true
+    return;
+  }
+  for (const line of preInitBuffer.splice(0)) appendLine(line)
+}
+
+function patchConsole({ tag = "MAIN", mirrorLog = true } = {}) {
+  mirrorLogEnabled = mirrorLog
+  for (const level of ["log", "info", "debug"]) {
+    console[level] = (...args) => {
+      writeLog(tag, level, ...args)
+      if (mirrorLog) origConsole[level](...args)
+    }
+  }
+  // warn/error always reach the console, matching pre-existing behavior
+  for (const level of ["warn", "error"]) {
+    console[level] = (...args) => {
+      writeLog(tag, level, ...args)
+      origConsole[level](...args)
+    }
+  }
+}
+
+// Log on behalf of another context (e.g. renderer logs arriving over IPC),
+// mirroring to the console under the same rules as console.log
+function logAs(tag, ...args) {
+  writeLog(tag, "log", ...args)
+  if (mirrorLogEnabled) origConsole.log(...args)
+}
+
+// Pipe a forked child's stdout/stderr (fork with silent: true) into the log,
+// re-emitting to the real stdout/stderr so console mode looks unchanged.
+// This captures native output (e.g. node-ddcci's std::cout), which JS-level
+// console patching inside the child cannot see.
+function attachChild(child, tag) {
+  const attach = (input, level, mirror) => {
+    if (!input) return;
+    const rl = readline.createInterface({ input, crlfDelay: Infinity })
+    rl.on("line", line => {
+      writeLog(tag, level, line)
+      mirror(line + "\n")
+    })
+    input.on("error", () => { })
+  }
+  attach(child.stdout, "log", realStdoutWrite)
+  attach(child.stderr, "error", realStderrWrite)
+  child.on("exit", (code, signal) => writeLog(tag, "log", `Child exited (code=${code}, signal=${signal})`))
+  child.on("error", err => writeLog(tag, "error", "Child error:", err))
+}
+
+function getSessionLogPath() { return sessionPath }
+
+function closeLogger() {
+  try { stream?.end() } catch (e) { }
+}
+
+module.exports = {
+  initMainLogger,
+  writeLog,
+  writeLogSync,
+  logAs,
+  patchConsole,
+  attachChild,
+  getSessionLogPath,
+  closeLogger
+}

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -27,7 +27,9 @@ let stream = null
 let sessionPath = null
 let bytesWritten = 0
 let capped = false
+let disabled = false
 let mirrorLogEnabled = true
+let initOpts = null
 const preInitBuffer = []
 
 const stripAnsi = (s) => s.replace(/\x1b\[[0-9;]*m/g, "")
@@ -52,7 +54,7 @@ function formatLine(tag, level, args) {
 }
 
 function appendLine(line) {
-  if (capped) return;
+  if (capped || disabled) return;
   if (!stream) {
     preInitBuffer.push(line)
     return;
@@ -73,13 +75,24 @@ function writeLog(tag, level, ...args) {
 // Synchronous write for fatal errors, where the process may die before the stream flushes
 function writeLogSync(tag, level, ...args) {
   const line = formatLine(tag, level, args)
-  if (capped || !sessionPath) return;
+  if (capped || disabled || !sessionPath) return;
   try {
     fs.appendFileSync(sessionPath, line)
   } catch (e) { }
 }
 
-function initMainLogger({ dir, isDev = false } = {}) {
+// Open a session log file. When enabled is false, no file is created or rotated
+// and all subsequent writes are dropped; console output is unaffected either way.
+function initMainLogger({ dir, isDev = false, enabled = true } = {}) {
+  initOpts = { dir, isDev }
+  if (!enabled) {
+    disabled = true
+    preInitBuffer.length = 0
+    return;
+  }
+  disabled = false
+  capped = false
+  bytesWritten = 0
   const logDir = path.join(dir, "logs")
   const suffix = isDev ? "-dev" : ""
   try {
@@ -154,6 +167,26 @@ function attachChild(child, tag) {
 
 function getSessionLogPath() { return sessionPath }
 
+function isLoggingEnabled() { return !disabled }
+
+// Turn file logging on/off at runtime (from the settings toggle). Enabling starts
+// a fresh session file; disabling stops writing and closes the current one.
+// Console output is never affected. No-op before initMainLogger has run.
+function setLoggingEnabled(enabled) {
+  if (!initOpts) return;
+  if (enabled) {
+    if (!disabled && stream) return; // already on
+    initMainLogger({ ...initOpts, enabled: true })
+    writeLog("MAIN", "log", "Logging enabled by user.")
+  } else {
+    if (disabled) return; // already off
+    writeLog("MAIN", "log", "Logging disabled by user.")
+    closeLogger()
+    stream = null
+    disabled = true
+  }
+}
+
 function closeLogger() {
   try { stream?.end() } catch (e) { }
 }
@@ -166,5 +199,7 @@ module.exports = {
   patchConsole,
   attachChild,
   getSessionLogPath,
+  isLoggingEnabled,
+  setLoggingEnabled,
   closeLogger
 }

--- a/src/Monitors.js
+++ b/src/Monitors.js
@@ -1618,7 +1618,8 @@ function getDDCCI() {
     if (ddcci) return false;
     try {
         ddcci = require("@hensm/ddcci");
-        if(isDev) ddcci._setLogLevel(2);
+        // Level 2 (verbose) in dev; level 1 (errors/warnings) otherwise, captured to the session log
+        ddcci._setLogLevel(isDev ? 2 : 1);
         return true;
     } catch (e) {
         console.log('Couldn\'t start DDC/CI', e);

--- a/src/components/SettingsWindow.jsx
+++ b/src/components/SettingsWindow.jsx
@@ -1592,6 +1592,7 @@ export default class SettingsWindow extends PureComponent {
                                     <SettingsOption title="Use GUID_VIDEO_CURRENT_MONITOR_BRIGHTNESS events" input={this.renderToggle("useGuidBrightnessEvent")} />
                                     <SettingsOption title="Reload tray icon on hardware events" input={this.renderToggle("reloadTray")} />
                                     <SettingsOption title="Reload flyout panel on hardware events" input={this.renderToggle("reloadFlyout")} />
+                                    <SettingsOption title="Save logs to file" description="Write a log file each session for troubleshooting. The last few sessions are kept in the app's data folder." input={this.renderToggle("logging")} />
                                     <SettingsOption title="Show console window (requires restart)" input={this.renderToggle("showConsole")} />
                                     <SettingsOption title="Use Taskbar Registry" input={this.renderToggle("useTaskbarRegistry")} />
                                     <SettingsOption title="Disable Mouse Events (requires restart)" input={this.renderToggle("disableMouseEvents")} />

--- a/src/electron.js
+++ b/src/electron.js
@@ -50,11 +50,6 @@ if(app.commandLine.hasSwitch("show-console")) {
   reopenAppWithConsole()
 }
 
-// Open the session log file. Earlier console output is buffered and flushed here.
-// Runs after the --show-console relaunch so the exiting stub doesn't rotate the logs.
-logger.initMainLogger({ dir: configFilesDir, isDev })
-console.log("Session log file: " + logger.getSessionLogPath())
-
 process.on("uncaughtException", (err) => {
   logger.writeLogSync("MAIN", "error", "UNCAUGHT EXCEPTION:", err)
   throw err
@@ -865,6 +860,7 @@ const defaultSettings = {
   udpPortActive: 14715,
   udpKey: uuid(),
   showConsole: false,
+  logging: true,
   profiles: [],
   uuid: uuid(),
   branch: (appVersionTag?.indexOf?.("beta") === 0 ? "beta" : "master"),
@@ -1048,6 +1044,13 @@ function readSettings(doProcessSettings = true) {
 }
 
 readSettings(false)
+
+// Open the session log file now that the `logging` preference is known. Earlier
+// console output was buffered by patchConsole and is flushed here. Runs after the
+// --show-console relaunch check so the exiting stub doesn't rotate the logs.
+logger.initMainLogger({ dir: configFilesDir, isDev, enabled: settings.logging })
+if (logger.isLoggingEnabled()) console.log("Session log file: " + logger.getSessionLogPath())
+
 if (settings.disableThrottling) {
   // Prevent background throttling
   app.commandLine.appendSwitch('disable-renderer-backgrounding');
@@ -1161,6 +1164,10 @@ function processSettings(newSettings = {}, sendUpdate = true) {
       if (!udp.server) udp.start(settings.udpPort);
     } else if (settings.udpEnabled === false) {
       if (udp.server) udp.stop();
+    }
+
+    if (newSettings.logging !== undefined) {
+      logger.setLoggingEnabled(settings.logging)
     }
 
     if (newSettings.order !== undefined) {

--- a/src/electron.js
+++ b/src/electron.js
@@ -18,6 +18,7 @@ const isAppX = (app.name == "twinkle-tray-appx" ? true : false)
 const isPortable = (app.name == "twinkle-tray-portable" ? true : false)
 
 const Utils = require("./Utils")
+const logger = require("./Logger")
 
 const configFilesDir = (isPortable ? path.join(__dirname, "../../config/") : app.getPath("userData"))
 const settingsPath = path.join(configFilesDir, `\\settings${(isDev ? "-dev" : "")}.json`)
@@ -30,6 +31,9 @@ if (!singleInstanceLock) {
   try { Utils.handleProcessedArgs(Utils.processArgs(process.argv, app), knownDisplaysPath, settingsPath).then(() => app.exit()) } catch (e) { app.exit() }
   return false
 } else {
+  // Tee console output into the session log file. In non-dev (without --console),
+  // console.log stays quiet on stdout but is still collected to the file.
+  logger.patchConsole({ tag: "MAIN", mirrorLog: (isDev || app.commandLine.hasSwitch("console")) })
   console.log("Starting Twinkle Tray...")
   app.on('second-instance', handleCommandLine)
 }
@@ -45,6 +49,19 @@ function reopenAppWithConsole() {
 if(app.commandLine.hasSwitch("show-console")) {
   reopenAppWithConsole()
 }
+
+// Open the session log file. Earlier console output is buffered and flushed here.
+// Runs after the --show-console relaunch so the exiting stub doesn't rotate the logs.
+logger.initMainLogger({ dir: configFilesDir, isDev })
+console.log("Session log file: " + logger.getSessionLogPath())
+
+process.on("uncaughtException", (err) => {
+  logger.writeLogSync("MAIN", "error", "UNCAUGHT EXCEPTION:", err)
+  throw err
+})
+process.on("unhandledRejection", (reason) => {
+  console.error("UNHANDLED REJECTION:", reason)
+})
 
 const { Readable } = require("node:stream")
 //require("os").setPriority(0, require("os").constants.priority.PRIORITY_BELOW_NORMAL)
@@ -120,7 +137,6 @@ const debug = {
   error: log
 }
 
-if (!isDev && !app.commandLine.hasSwitch("console")) console.log = () => { };
 
 
 const windowMenu = Menu.buildFromTemplate([{
@@ -335,7 +351,8 @@ function startMonitorThread({ allowWhileWindowsIdle = false } = {}) {
   monitorsThreadStarting = true
   console.log("Starting monitor thread")
   const skipTest = (settings.preferredDDCCIMethod == "auto" ? false : true)
-  monitorsThreadReal = fork(path.join(__dirname, 'Monitors.js'), ["--isdev=" + isDev, "--apppath=" + app.getAppPath(), "--skiptest=" + skipTest, "--datapath=" + app.getPath("userData")], { silent: false })
+  monitorsThreadReal = fork(path.join(__dirname, 'Monitors.js'), ["--isdev=" + isDev, "--apppath=" + app.getAppPath(), "--skiptest=" + skipTest, "--datapath=" + app.getPath("userData")], { silent: true })
+  logger.attachChild(monitorsThreadReal, "MON")
   const monitorThread = monitorsThreadReal
   monitorThread.on("message", (data) => {
     if (data?.type) {
@@ -573,7 +590,8 @@ let monitorsThreadTest
 let wmiBridgeOK = false
 async function doWMIBridgeTest() {
   return new Promise((resolve, reject) => {
-    monitorsThreadTest = fork(path.join(__dirname, 'wmi-bridge-test.js'), ["--isdev=" + isDev, "--apppath=" + app.getAppPath()], { silent: false })
+    monitorsThreadTest = fork(path.join(__dirname, 'wmi-bridge-test.js'), ["--isdev=" + isDev, "--apppath=" + app.getAppPath()], { silent: true })
+    logger.attachChild(monitorsThreadTest, "WMI-TEST")
     monitorsThreadTest.on("message", (data) => {
       if (data?.type === "ready") {
         console.log("WMI-BRIDGE TEST: READY")
@@ -3046,7 +3064,16 @@ ipcMain.on('get-refreshing', () => {
 
 ipcMain.on('open-settings', createSettings)
 
-ipcMain.on('log', (e, msg) => console.log(msg))
+function getSenderLogTag(sender) {
+  try {
+    if (sender === mainWindow?.webContents) return "PANEL";
+    if (sender === settingsWindow?.webContents) return "SETTINGS";
+    if (sender === introWindow?.webContents) return "INTRO";
+  } catch (e) { }
+  return "WIN"
+}
+
+ipcMain.on('log', (e, msg) => logger.logAs(getSenderLogTag(e.sender), msg))
 
 ipcMain.on('pause-updates', pauseMonitorUpdates)
 
@@ -3929,6 +3956,7 @@ app.on('quit', () => {
   } catch (e) {
 
   }
+  logger.closeLogger()
 })
 
 

--- a/src/intro-preload.js
+++ b/src/intro-preload.js
@@ -1,5 +1,13 @@
 const { ipcRenderer: ipc } = require('electron');
 
+// Send logs to main thread
+const con = {
+    log: console.log,
+    error: console.error
+}
+console.log = (...e) => { e.forEach((c) => { ipc.send('log', c); con.log(c) }) }
+console.error = (...e) => { e.forEach((c) => { ipc.send('log', c); con.error(c) }) }
+
 window.closeIntro = () => {
     ipc.send('close-intro')
 }

--- a/src/panel-preload.js
+++ b/src/panel-preload.js
@@ -259,10 +259,10 @@ ipc.on('isRefreshing', (event, newValue) => {
 // Settings recieved
 ipc.on('settings-updated', (event, settings) => {
     if (settings.isDev == false) {
-        console.log = () => { }
-    } else {
-        console.log = log
+        // Keep forwarding to the main process session log; stay quiet in DevTools
         console.log = (...e) => { e.forEach((c) => ipc.send('log', c)) }
+    } else {
+        console.log = (...e) => { e.forEach((c) => { ipc.send('log', c); con.log(c) }) }
     }
     window.settings = settings
     detectSunValley()


### PR DESCRIPTION
## What

All console output — main process, forked children, native modules, and renderer windows — is now also written to a per-session log file, rotated so at most **3 session files** are kept. Console behavior is unchanged: quiet in production, live in dev / `--console` mode.

Log files live at `%APPDATA%\twinkle-tray\logs\session-YYYYMMDD-HHMMSS-<pid>.log` (portable: `config\logs\`). Dev sessions use a `-dev` suffix and rotate as a separate pool, so dev testing never evicts a user's production logs. Lines are formatted `[HH:MM:SS.mmm] [TAG] message` with tags `MAIN`, `MON`, `WMI-TEST`, `PANEL`, `SETTINGS`, `INTRO`.

## Why

In production, `console.log` was a no-op, renderer logs were dropped, and native ddcci output was silent — so when users report DDC/CI issues or the app disappearing, there's nothing to collect. Now the last 3 sessions of full diagnostics are always on disk.

## How

- **`src/Logger.js` (new)** — single-writer design: the main process owns one write stream per session. Handles rotation, timestamped/tagged formatting, ANSI stripping (file only; console keeps colors), safe object/Error serialization, pre-init buffering, a 50 MB runaway cap, and fail-silent disk errors.
- **Main process** — `console.*` is teed: the file always gets everything; stdout only mirrors `.log` output in dev/`--console`, matching prior visibility exactly. Uncaught exceptions are logged synchronously then rethrown (fatal behavior preserved); unhandled rejections route through `console.error`.
- **Children** — the `Monitors.js` and `wmi-bridge-test.js` forks switch to `silent: true`, with stdout/stderr piped line-by-line into the log and re-emitted to the real console. Piping the OS-level fd is what captures **native output** (node-ddcci's `std::cout`) that JS console patching can't see. ddcci's native log level is now 1 in production (errors/warnings, previously fully silent), still 2 in dev.
- **Renderers** — panel logs keep forwarding over the existing `'log'` IPC channel in production (quiet in DevTools) instead of being dropped; the main-side handler tags by sender window; intro window gets the same forwarding shim. Also fixes a pre-existing bug where dev-mode panel logs lost their DevTools echo.
- **`package.json`** — `src/Logger.js` added to `build.files` (main-process files ship from that allow-list).

## Reviewer notes

- Known limitation: native stdout from addons loaded *in the main process itself* (e.g. win32-displayconfig) can't be intercepted — all known native logging (ddcci) lives in the Monitors child, which is captured via the pipe.
- The legacy `debug[-dev].log` writer is untouched; its output also flows into the session log via the teed `console.log`.
- Rotation only runs in the instance that wins the single-instance lock, and after the `--show-console` relaunch check, so short-lived stub processes don't churn the log pool.

## Testing

- Standalone harness: 11/11 checks (pre-init buffering, serialization, ANSI stripping, child stdout/stderr capture including split partial writes, exit logging, tags, timestamps); rotation verified (4 runs → 3 files, dev pool independent).
- Live dev run: session log filled with `[MAIN]`, `[MON]`, `[WMI-TEST]`, and 232 `[node-ddcci]` lines, zero errors, terminal output unchanged including colors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
