### PR TITLE
Add native brightness keys as configurable hotkeys

### DIFF
--- a/src/components/SettingsWindow.jsx
+++ b/src/components/SettingsWindow.jsx
@@ -151,6 +151,7 @@ export default class SettingsWindow extends PureComponent {
         }
         this.numMonitors = 0
         this.downKeys = {}
+        this.recordingHotkeyId = false
         this.lastLevels = []
         this.onDragEnd = this.onDragEnd.bind(this);
         this.sendSettingsTimeout = false
@@ -176,6 +177,7 @@ export default class SettingsWindow extends PureComponent {
         window.addEventListener("monitorsUpdated", this.recievedMonitors)
         window.addEventListener("settingsUpdated", this.recievedSettings)
         window.addEventListener("ddcSafetyStatus", this.recievedDDCSafetyStatus)
+        window.addEventListener("nativeBrightnessKey", this.recievedNativeBrightnessKey)
         window.addEventListener("localizationUpdated", (e) => { this.setState({ languages: e.detail.languages });  T.setLocalizationData(e.detail.desired, e.detail.default)}); 
         window.addEventListener("windowHistory", e => this.setState({ windowHistory: e.detail }))
 
@@ -207,6 +209,11 @@ export default class SettingsWindow extends PureComponent {
         window.ipc.send('request-localization')
         window.requestDDCSafetyStatus()
         window.reactReady = true
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener("nativeBrightnessKey", this.recievedNativeBrightnessKey)
+        window.ipc.send("set-native-hotkey-recording", false)
     }
 
 
@@ -744,7 +751,14 @@ export default class SettingsWindow extends PureComponent {
             return (
                 <SettingsOption className="win10-has-background" key={hotkey.id} content={
                     <div className="row hotkey-combo-input">
-                        <input placeholder={T.t("SETTINGS_HOTKEYS_PRESS_KEYS_HINT")} value={hotkey.accelerator} type="text" readOnly={true} onKeyDown={
+                        <input placeholder={T.t("SETTINGS_HOTKEYS_PRESS_KEYS_HINT")} value={hotkey.accelerator} type="text" readOnly={true} onFocus={() => {
+                            this.recordingHotkeyId = hotkey.id
+                            window.ipc.send("set-native-hotkey-recording", true)
+                        }} onBlur={() => {
+                            this.recordingHotkeyId = false
+                            this.downKeys = {}
+                            window.ipc.send("set-native-hotkey-recording", false)
+                        }} onKeyDown={
                             (e) => {
                                 e.preventDefault()
                                 let key = cleanUpKeyboardKeys(e.key, e.keyCode)
@@ -785,6 +799,15 @@ export default class SettingsWindow extends PureComponent {
                 </SettingsOption>
             )
         })
+    }
+
+    recievedNativeBrightnessKey = (e) => {
+        const idx = this.state.hotkeys.findIndex(hotkey => hotkey.id === this.recordingHotkeyId)
+        if(idx < 0) return;
+        this.downKeys = {}
+        const hotkey = this.state.hotkeys[idx]
+        hotkey.accelerator = e.detail
+        this.updateHotkey(hotkey, idx)
     }
 
     getHotkeyStatusIcon = hotkey => {

--- a/src/components/SettingsWindow.jsx
+++ b/src/components/SettingsWindow.jsx
@@ -1179,6 +1179,10 @@ export default class SettingsWindow extends PureComponent {
     }
 
     render() {
+        const hasNativeBrightnessHotkey = this.state.hotkeys?.some(hotkey => (
+            hotkey.accelerator === "BrightnessUp" || hotkey.accelerator === "BrightnessDown"
+        ))
+
         return (
             <SafeRender>
                 <div className="window-base" data-theme={window.settings.theme || "default"}>
@@ -1442,6 +1446,9 @@ export default class SettingsWindow extends PureComponent {
                                 <div className="pageSection">
                                     <div className="sectionTitle">{T.t("SETTINGS_HOTKEYS_TITLE")}</div>
                                     <p>{T.t("SETTINGS_HOTKEYS_DESC")}</p>
+                                    {hasNativeBrightnessHotkey ? (
+                                        <p>⚠️ <em>{T.t("SETTINGS_HOTKEYS_NATIVE_BRIGHTNESS_WARN")}</em></p>
+                                    ) : null}
                                     <div className="hotkey-monitors">
                                         {this.getHotkeyList()}
                                         <p><a className="button" onClick={() => {

--- a/src/electron.js
+++ b/src/electron.js
@@ -80,7 +80,7 @@ const { fork, exec } = require('child_process');
 const { VerticalRefreshRateContext, addDisplayChangeListener } = require("win32-displayconfig");
 const refreshCtx = new VerticalRefreshRateContext();
 
-const {WindowUtils, MediaStatus, PowerEvents, AppStartup} = require("tt-windows-utils")
+const {WindowUtils, BrightnessKeys, MediaStatus, PowerEvents, AppStartup} = require("tt-windows-utils")
 const setWindowPos = () => { }
 const AccentColors = require("windows-accent-colors")
 const Acrylic = require("acrylic")
@@ -622,6 +622,78 @@ async function doWMIBridgeTest() {
 let mouseEventsActive = false
 let mouseEvents
 let bounds
+
+const nativeBrightnessAccelerators = {
+  up: "BrightnessUp",
+  down: "BrightnessDown"
+}
+let nativeBrightnessKeysRegistered = false
+let nativeHotkeyRecording = false
+let nativeBrightnessKey = false
+let nativeBrightnessKeyRepeatDelay = false
+let nativeBrightnessKeyRepeat = false
+
+function stopNativeBrightnessKeyRepeat() {
+  nativeBrightnessKey = false
+  if(nativeBrightnessKeyRepeatDelay) clearTimeout(nativeBrightnessKeyRepeatDelay);
+  if(nativeBrightnessKeyRepeat) clearInterval(nativeBrightnessKeyRepeat);
+  nativeBrightnessKeyRepeatDelay = false
+  nativeBrightnessKeyRepeat = false
+}
+
+function triggerNativeBrightnessHotkey(direction) {
+  const accelerator = nativeBrightnessAccelerators[direction]
+  if(!accelerator) return false;
+
+  if(nativeHotkeyRecording && settingsWindow?.isFocused()) {
+    settingsWindow.webContents.send("native-brightness-key", accelerator)
+    return false
+  }
+
+  const hotkey = settings.hotkeys?.find?.(item => item.accelerator === accelerator)
+  if(!hotkey) return false;
+  // Windows already applies dedicated brightness keys to the built-in panel.
+  // Avoid applying a configured offset to that panel a second time.
+  doHotkey(hotkey, { skipInternalBrightnessOffset: true })
+  return true
+}
+
+function handleNativeBrightnessKey(key) {
+  if(key === "release") {
+    stopNativeBrightnessKeyRepeat()
+    return
+  }
+  if(key !== "up" && key !== "down") return;
+  if(nativeBrightnessKey === key) return;
+
+  stopNativeBrightnessKeyRepeat()
+  nativeBrightnessKey = key
+  if(!triggerNativeBrightnessHotkey(key)) {
+    nativeBrightnessKey = false
+    return
+  }
+  nativeBrightnessKeyRepeatDelay = setTimeout(() => {
+    nativeBrightnessKeyRepeat = setInterval(() => {
+      if(nativeBrightnessKey) triggerNativeBrightnessHotkey(nativeBrightnessKey)
+    }, 100)
+  }, 400)
+}
+
+function applyNativeBrightnessKeys() {
+  try {
+    stopNativeBrightnessKeyRepeat()
+    BrightnessKeys.unregister()
+    nativeBrightnessKeysRegistered = false
+    if(mainWindow) {
+      nativeBrightnessKeysRegistered = BrightnessKeys.register(getMainWindowHandle())
+      console.log(`Native brightness keys: ${nativeBrightnessKeysRegistered ? "enabled" : "unavailable"}`)
+    }
+  } catch(e) {
+    console.log("Couldn't apply native brightness keys:", e)
+  }
+  applyHotkeys()
+  return nativeBrightnessKeysRegistered
+}
 
 function enableMouseEvents() {
   if (mouseEventsActive || settings.disableMouseEvents) return false;
@@ -1464,15 +1536,22 @@ function applyProfile(profile = {}, useTransition = false, transitionSpeed = 1, 
 
 function applyHotkeys(monitorList = monitors) {
   try {
+    globalShortcut.unregisterAll()
+    const claimedNativeAccelerators = new Set()
     if (settings.hotkeys !== undefined && settings.hotkeys?.length) {
-      globalShortcut.unregisterAll()
       for (const hotkey of settings.hotkeys) {
+        hotkey.active = false
         try {
           // Only apply if found/valid
           if (hotkey.accelerator) {
-            hotkey.active = globalShortcut.register(hotkey.accelerator, () => {
-              doHotkey(hotkey)
-            })
+            if(Object.values(nativeBrightnessAccelerators).includes(hotkey.accelerator)) {
+              hotkey.active = nativeBrightnessKeysRegistered && !claimedNativeAccelerators.has(hotkey.accelerator)
+              claimedNativeAccelerators.add(hotkey.accelerator)
+            } else {
+              hotkey.active = globalShortcut.register(hotkey.accelerator, () => {
+                doHotkey(hotkey)
+              })
+            }
           }
         } catch (e) {
           // Couldn't register hotkey
@@ -1490,7 +1569,7 @@ let hotkeyOverlayTimeout
 let hotkeyThrottle = []
 let doingHotkey = false
 const hotkeyCycleIndexes = []
-async function doHotkey(hotkey) {
+async function doHotkey(hotkey, options = {}) {
   const now = Date.now()
   if (!doingHotkey && (hotkeyThrottle[hotkey.id] === undefined || now > hotkeyThrottle[hotkey.id] + 100)) {
 
@@ -1534,6 +1613,10 @@ async function doHotkey(hotkey) {
             } else if (Object.keys(action.monitors)?.length && action.monitors[monitor.id]) {
               // Target specified monitors
               applicable = true
+            }
+
+            if(options.skipInternalBrightnessOffset && action.type === "offset" && action.target === "brightness" && monitor.type === "wmi") {
+              applicable = false
             }
 
             if (applicable) {
@@ -3331,6 +3414,9 @@ function createPanel(toggleOnLoad = false, isRefreshing = false, showOnLoad = tr
   mainWindow.on("closed", () => {
     console.log("~~~~~ MAIN WINDOW CLOSED ~~~~~~")
     PowerEvents.unregisterPowerSettingNotifications()
+    BrightnessKeys.unregister()
+    nativeBrightnessKeysRegistered = false
+    stopNativeBrightnessKeyRepeat()
     mainWindow = null
   });
   mainWindow.on("minimize", () => { console.log("~~~~~ MAIN WINDOW MINIMIZED ~~~~~~") });
@@ -3394,6 +3480,15 @@ function createPanel(toggleOnLoad = false, isRefreshing = false, showOnLoad = tr
 
   mainWindow.hookWindowMessage(126, (wParam, lParam) => {
     if(settings.useWmDisplayChangeEvent && !settings.disablePowerNotifications) handleMetricsChange("wm_displaychange")
+  })
+
+  // WM_INPUT: HID Consumer Control brightness increment/decrement reports.
+  mainWindow.hookWindowMessage(0x00FF, (wParam, lParam) => {
+    try {
+      handleNativeBrightnessKey(BrightnessKeys.getKey(lParam.readBigUInt64LE(0)))
+    } catch(e) {
+      console.log("Couldn't process native brightness key:", e)
+    }
   })
 
   // WM_POWERBROADCAST
@@ -3465,6 +3560,7 @@ function createPanel(toggleOnLoad = false, isRefreshing = false, showOnLoad = tr
   })
 
   if(!settings.disablePowerNotifications) PowerEvents.registerPowerSettingNotifications(getMainWindowHandle())
+  applyNativeBrightnessKeys()
 
 }
 
@@ -4052,6 +4148,9 @@ app.on("activate", () => {
 app.on('quit', () => {
   try {
     PowerEvents.unregisterPowerSettingNotifications()
+    BrightnessKeys.unregister()
+    nativeBrightnessKeysRegistered = false
+    stopNativeBrightnessKeyRepeat()
     tray.destroy()
   } catch (e) {
 
@@ -4345,6 +4444,12 @@ ipcMain.on('close-intro', (event, newSettings) => {
 //
 
 let settingsWindow
+
+ipcMain.on("set-native-hotkey-recording", (event, recording) => {
+  if(settingsWindow?.webContents.id !== event.sender.id) return;
+  nativeHotkeyRecording = Boolean(recording)
+})
+
 function createSettings() {
 
   if (settingsWindow != null) {
@@ -4419,7 +4524,10 @@ function createSettings() {
       : `file://${path.join(__dirname, "../build/settings.html")}`
   );
 
-  settingsWindow.on("closed", () => (settingsWindow = null));
+  settingsWindow.on("closed", () => {
+    nativeHotkeyRecording = false
+    settingsWindow = null
+  });
 
   settingsWindow.on("move", sendSettingsBounds)
   settingsWindow.on("resize", sendSettingsBounds)

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -196,6 +196,7 @@
     "SETTINGS_TIME_IDLE_MEDIA_DESC": "Idle detection will be disabled while any media is playing. This includes both video and audio. This only applies when Windows reports that media is playing.",
     "SETTINGS_HOTKEYS_TITLE": "Hotkeys",
     "SETTINGS_HOTKEYS_DESC": "Configure hotkeys to adjust the brightness of one or all displays.",
+    "SETTINGS_HOTKEYS_NATIVE_BRIGHTNESS_WARN": "Windows will still adjust the built-in display when a brightness key is pressed. Do not use a BrightnessUp or BrightnessDown hotkey to adjust the built-in display's brightness.",
     "SETTINGS_HOTKEYS_ADD": "Add Hotkey",
     "SETTINGS_HOTKEYS_REMOVE": "Remove hotkey",
     "SETTINGS_HOTKEYS_INCREASE": "Increase Brightness",

--- a/src/modules/tt-windows-utils/binding.gyp
+++ b/src/modules/tt-windows-utils/binding.gyp
@@ -1,6 +1,20 @@
 {
   "targets": [
     {
+      "target_name": "windows_brightness_keys",
+      "cflags!": [ ],
+      "cflags_cc!": [ ],
+      "sources": [ "windows_brightness_keys.cc" ],
+      "include_dirs": [
+        "<!@(node -p \"require('node-addon-api').include\")"
+      ],
+      "libraries": [ "hid.lib" ],
+      'msvs_settings': {
+        'VCCLCompilerTool': { "ExceptionHandling": 1 }
+      },
+      'defines': [ 'NAPI_CPP_EXCEPTIONS' ],
+    },
+    {
       "target_name": "windows_window_utils",
       "cflags!": [ ],
       "cflags_cc!": [ ],

--- a/src/modules/tt-windows-utils/index.js
+++ b/src/modules/tt-windows-utils/index.js
@@ -1,11 +1,17 @@
 "use strict";
 const WindowUtils = require("bindings")("windows_window_utils");
+const BrightnessKeys = require("bindings")("windows_brightness_keys");
 const PowerEvents = require("bindings")("windows_power_events");
 const MediaStatus = require("bindings")("windows_media_status");
 const AppStartup = require("bindings")("windows_app_startup");
 const WindowMaterial = require("bindings")("windows_window_material");
 
 module.exports = {
+    BrightnessKeys: {
+        register: BrightnessKeys.register,
+        unregister: BrightnessKeys.unregister,
+        getKey: BrightnessKeys.getKey
+    },
     WindowUtils: {
         setWindowPos: WindowUtils.setWindowPos,
         getWindowPos: WindowUtils.getWindowPos,

--- a/src/modules/tt-windows-utils/package.json
+++ b/src/modules/tt-windows-utils/package.json
@@ -20,6 +20,7 @@
   "files": [
     "index.js",
     "binding.gyp",
+    "windows_brightness_keys.cc",
     "windows_media_status.cc",
     "windows_power_events.cc",
     "windows_window_utils.cc",

--- a/src/modules/tt-windows-utils/windows_brightness_keys.cc
+++ b/src/modules/tt-windows-utils/windows_brightness_keys.cc
@@ -1,0 +1,187 @@
+#include <napi.h>
+#include <windows.h>
+#include <hidusage.h>
+#include <hidpi.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr USAGE kConsumerUsagePage = 0x0C;
+constexpr USAGE kConsumerControlUsage = 0x01;
+constexpr USAGE kBrightnessIncrementUsage = 0x006F;
+constexpr USAGE kBrightnessDecrementUsage = 0x0070;
+
+bool GetWindowHandle(const Napi::Value& value, HWND* handle)
+{
+    if (value.IsBigInt()) {
+        bool lossless = false;
+        uint64_t rawHandle = value.As<Napi::BigInt>().Uint64Value(&lossless);
+        if (!lossless) return false;
+        *handle = reinterpret_cast<HWND>(static_cast<uintptr_t>(rawHandle));
+        return true;
+    }
+
+    if (value.IsNumber()) {
+        *handle = reinterpret_cast<HWND>(
+          static_cast<intptr_t>(value.As<Napi::Number>().Int64Value()));
+        return true;
+    }
+
+    return false;
+}
+
+Napi::Boolean RegisterBrightnessKeys(const Napi::CallbackInfo& info)
+{
+    HWND hwnd = NULL;
+    if (info.Length() < 1 || !GetWindowHandle(info[0], &hwnd) || hwnd == NULL) {
+        return Napi::Boolean::New(info.Env(), false);
+    }
+
+    RAWINPUTDEVICE device = {};
+    device.usUsagePage = kConsumerUsagePage;
+    device.usUsage = kConsumerControlUsage;
+    device.dwFlags = RIDEV_INPUTSINK;
+    device.hwndTarget = hwnd;
+
+    return Napi::Boolean::New(
+      info.Env(), RegisterRawInputDevices(&device, 1, sizeof(device)) != FALSE);
+}
+
+Napi::Boolean UnregisterBrightnessKeys(const Napi::CallbackInfo& info)
+{
+    RAWINPUTDEVICE device = {};
+    device.usUsagePage = kConsumerUsagePage;
+    device.usUsage = kConsumerControlUsage;
+    device.dwFlags = RIDEV_REMOVE;
+    device.hwndTarget = NULL;
+
+    return Napi::Boolean::New(
+      info.Env(), RegisterRawInputDevices(&device, 1, sizeof(device)) != FALSE);
+}
+
+std::string ReadBrightnessKey(HRAWINPUT inputHandle)
+{
+    UINT inputSize = 0;
+    if (GetRawInputData(inputHandle,
+                        RID_INPUT,
+                        NULL,
+                        &inputSize,
+                        sizeof(RAWINPUTHEADER)) == static_cast<UINT>(-1) ||
+        inputSize < sizeof(RAWINPUTHEADER)) {
+        return "";
+    }
+
+    std::vector<BYTE> inputBuffer(inputSize);
+    if (GetRawInputData(inputHandle,
+                        RID_INPUT,
+                        inputBuffer.data(),
+                        &inputSize,
+                        sizeof(RAWINPUTHEADER)) == static_cast<UINT>(-1)) {
+        return "";
+    }
+
+    RAWINPUT* input = reinterpret_cast<RAWINPUT*>(inputBuffer.data());
+    if (input->header.dwType != RIM_TYPEHID || input->header.hDevice == NULL) {
+        return "";
+    }
+
+    UINT preparsedSize = 0;
+    if (GetRawInputDeviceInfo(input->header.hDevice,
+                              RIDI_PREPARSEDDATA,
+                              NULL,
+                              &preparsedSize) == static_cast<UINT>(-1) ||
+        preparsedSize == 0) {
+        return "";
+    }
+
+    std::vector<BYTE> preparsedBuffer(preparsedSize);
+    if (GetRawInputDeviceInfo(input->header.hDevice,
+                              RIDI_PREPARSEDDATA,
+                              preparsedBuffer.data(),
+                              &preparsedSize) == static_cast<UINT>(-1)) {
+        return "";
+    }
+
+    PHIDP_PREPARSED_DATA preparsedData =
+      reinterpret_cast<PHIDP_PREPARSED_DATA>(preparsedBuffer.data());
+    HIDP_CAPS capabilities = {};
+    if (HidP_GetCaps(preparsedData, &capabilities) != HIDP_STATUS_SUCCESS ||
+        capabilities.UsagePage != kConsumerUsagePage ||
+        capabilities.Usage != kConsumerControlUsage) {
+        return "";
+    }
+
+    const RAWHID& hid = input->data.hid;
+    const size_t dataOffset = input->data.hid.bRawData - inputBuffer.data();
+    const size_t rawDataSize =
+      static_cast<size_t>(hid.dwSizeHid) * static_cast<size_t>(hid.dwCount);
+    if (hid.dwSizeHid == 0 || hid.dwCount == 0 ||
+        dataOffset > inputBuffer.size() ||
+        rawDataSize > inputBuffer.size() - dataOffset) {
+        return "";
+    }
+
+    const ULONG maxUsageCount = HidP_MaxUsageListLength(
+      HidP_Input, kConsumerUsagePage, preparsedData);
+    if (maxUsageCount == 0) return "";
+
+    std::vector<USAGE> usages(maxUsageCount);
+    bool parsedConsumerReport = false;
+    for (DWORD reportIndex = 0; reportIndex < hid.dwCount; reportIndex++) {
+        PCHAR report = reinterpret_cast<PCHAR>(
+          input->data.hid.bRawData + (reportIndex * hid.dwSizeHid));
+        ULONG usageCount = maxUsageCount;
+        // This is a valid Consumer Control report even when its usage list is
+        // empty (the documented key-release report uses usage value zero).
+        parsedConsumerReport = true;
+        NTSTATUS usageStatus = HidP_GetUsages(HidP_Input,
+                                              kConsumerUsagePage,
+                                              0,
+                                              usages.data(),
+                                              &usageCount,
+                                              preparsedData,
+                                              report,
+                                              hid.dwSizeHid);
+        if (usageStatus != HIDP_STATUS_SUCCESS) continue;
+        for (ULONG usageIndex = 0; usageIndex < usageCount; usageIndex++) {
+            if (usages[usageIndex] == kBrightnessIncrementUsage) return "up";
+            if (usages[usageIndex] == kBrightnessDecrementUsage) return "down";
+        }
+    }
+
+    // Consumer Control devices send a zero-usage report when a key is released.
+    return parsedConsumerReport ? "release" : "";
+}
+
+Napi::String GetBrightnessKey(const Napi::CallbackInfo& info)
+{
+    if (info.Length() < 1 || !info[0].IsBigInt()) {
+        return Napi::String::New(info.Env(), "");
+    }
+
+    bool lossless = false;
+    uint64_t rawHandle = info[0].As<Napi::BigInt>().Uint64Value(&lossless);
+    if (!lossless || rawHandle == 0) {
+        return Napi::String::New(info.Env(), "");
+    }
+
+    HRAWINPUT inputHandle = reinterpret_cast<HRAWINPUT>(
+      static_cast<uintptr_t>(rawHandle));
+    return Napi::String::New(info.Env(), ReadBrightnessKey(inputHandle));
+}
+
+} // namespace
+
+Napi::Object Init(Napi::Env env, Napi::Object exports)
+{
+    exports.Set("register", Napi::Function::New(env, RegisterBrightnessKeys));
+    exports.Set("unregister", Napi::Function::New(env, UnregisterBrightnessKeys));
+    exports.Set("getKey", Napi::Function::New(env, GetBrightnessKey));
+    return exports;
+}
+
+NODE_API_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/src/modules/windows-ambient-sensor/package.json
+++ b/src/modules/windows-ambient-sensor/package.json
@@ -21,6 +21,7 @@
   "files": [
     "index.js",
     "binding.gyp",
+    "utils.hpp",
     "windows_ambient_sensor.cc",
     "build/"
   ]

--- a/src/modules/windows-ambient-sensor/package.json
+++ b/src/modules/windows-ambient-sensor/package.json
@@ -21,7 +21,6 @@
   "files": [
     "index.js",
     "binding.gyp",
-    "utils.hpp",
     "windows_ambient_sensor.cc",
     "build/"
   ]

--- a/src/settings-preload.js
+++ b/src/settings-preload.js
@@ -175,6 +175,12 @@ ipc.on('settings-updated', (event, settings) => {
     }))
 })
 
+ipc.on('native-brightness-key', (event, accelerator) => {
+    window.dispatchEvent(new CustomEvent('nativeBrightnessKey', {
+        detail: accelerator
+    }))
+})
+
 ipc.on('ddc-safety-status', (event, status) => {
     window.dispatchEvent(new CustomEvent('ddcSafetyStatus', {
         detail: status


### PR DESCRIPTION
Capture Windows brightness-key HID events through the native utility module.
Allow BrightnessUp and BrightnessDown to use the existing hotkey action system.