### PR TITLE
Add Sceptre M27 (SPT0ACD) brightness VCP override

### DIFF
--- a/src/monitor-rules.json
+++ b/src/monitor-rules.json
@@ -1,7 +1,8 @@
 {
     "ddcBrightnessCodes": {
         "FUS087C": 107,
-        "FUS06AB": 19
+        "FUS06AB": 19,
+        "SPT0ACD": 16
     },
     "skipReapply": [
         "DEL41D9"


### PR DESCRIPTION
Adds a `ddcBrightnessCodes` override for the **Sceptre M27** (`SPT0ACD`).

### Problem

The Sceptre M27 reports a truncated MCCS capabilities string. It advertises only `vcp(02)` and omits `0x10` (luminance):

```
CAPS (103 bytes): (prot(monitor)type(LCD)model(RTK)cmds(01 02 03 07 0C E3 F3)vcp(02)mswhql(1)asset_eep(40)mccs_ver(2.2))
```

Since a report *does* exist, `checkIfVCPSupported()` short-circuits at `Monitors.js:1003`:

```js
if (hasReport && !isInReport) return false;
```

`0x10` is never actually probed. `determineBrightnessVCPCode()` falls through all four candidates and returns `false`, so at `Monitors.js:331` the display resolves to `type: "none"` and gets no brightness slider.

### The monitor does support 0x10

The capabilities string is simply wrong. Verified directly against `dxva2.dll`, outside of Twinkle Tray:

```
DEVICE: \\.\DISPLAY8   (Sceptre M27, HDMI)
  GetMonitorBrightness: OK  min=0 cur=30 max=100
  GetVCPFeatureAndVCPFeatureReply 0x10 -> cur=30 max=100
  SetVCPFeature 0x10 = 90 -> readback 90   (screen visibly brightened)
  SetVCPFeature 0x10 = 20 -> readback 20   (screen visibly dimmed)
  SetVCPFeature 0x10 = 30 -> readback 30   (restored)
```

Both read and write work reliably on the first attempt, no retries needed.

### Result

With `"SPT0ACD": 16` in `monitor-rules.json`, `determineBrightnessVCPCode()` returns early at `Monitors.js:767` and the display is classified correctly:

```
Display 1      type=none     brightnessType=false   (internal laptop panel)
ARZOPA         type=ddcci    brightnessType=16
Sceptre M27    type=ddcci    brightnessType=16      <-- now works
```

I confirmed the same fix works via the per-user `userDDCBrightnessVCPs` setting before proposing it here; this just makes it automatic for other M27 owners.

### Test setup

- Twinkle Tray v1.17.2
- Windows 11 Pro 26200
- Sceptre M27 over HDMI, Intel Iris Xe / NVIDIA MX450 hybrid laptop
- A second external monitor (Arzopa, `GWD0156`) on the same machine works out of the box, so this is specific to the M27's firmware

### Related

The per-monitor **custom VCP code** field in `MonitorFeatures.jsx` cannot be used to work around this from the UI, because it is gated on `monitor.features["0x10"]` being truthy (`MonitorFeatures.jsx:39`) — precisely the condition that fails here. Filed separately as #1300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
